### PR TITLE
#13/feat/study detail card

### DIFF
--- a/components/StudyDetailCard/StudyDetailCard.stories.tsx
+++ b/components/StudyDetailCard/StudyDetailCard.stories.tsx
@@ -11,4 +11,25 @@ const Template: ComponentStory<typeof StudyDetailCard> = (args) => (
 );
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  member: [
+    {
+      userId: "string",
+      name: "string",
+      email: "string",
+      img: "https://picsum.photos/200",
+    },
+    {
+      userId: "string",
+      name: "string",
+      email: "string",
+      img: "https://picsum.photos/200",
+    },
+    {
+      userId: "string",
+      name: "string",
+      email: "string",
+      img: "string",
+    },
+  ],
+};

--- a/components/StudyDetailCard/StudyDetailCard.stories.tsx
+++ b/components/StudyDetailCard/StudyDetailCard.stories.tsx
@@ -12,6 +12,8 @@ const Template: ComponentStory<typeof StudyDetailCard> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
+  title:
+    "안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요안녕하새요",
   member: [
     {
       userId: "string",
@@ -20,13 +22,13 @@ Default.args = {
       img: "https://picsum.photos/200",
     },
     {
-      userId: "string",
+      userId: "string2",
       name: "string",
       email: "string",
       img: "https://picsum.photos/200",
     },
     {
-      userId: "string",
+      userId: "string3",
       name: "string",
       email: "string",
       img: "string",

--- a/components/StudyDetailCard/StudyDetailCard.stories.tsx
+++ b/components/StudyDetailCard/StudyDetailCard.stories.tsx
@@ -1,0 +1,14 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { StudyDetailCard } from ".";
+
+export default {
+  title: "components/StudyDetailCard",
+  component: StudyDetailCard,
+} as ComponentMeta<typeof StudyDetailCard>;
+
+const Template: ComponentStory<typeof StudyDetailCard> = (args) => (
+  <StudyDetailCard {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/components/StudyDetailCard/StudyDetailCard.tsx
+++ b/components/StudyDetailCard/StudyDetailCard.tsx
@@ -1,6 +1,5 @@
-import Image from "next/image";
 import { MouseEvent, useState } from "react";
-import { AvatarGroup, Avatar, Menu, MenuItem } from "@mui/material";
+import { AvatarGroup, Avatar, Menu } from "@mui/material";
 import { StudyState } from "./StudyState";
 import * as S from "./style";
 import type { User } from "../../types/userType";
@@ -52,7 +51,7 @@ export const StudyDetailCard = ({
   };
 
   const userOnClick = (userId: string) => {
-    // console.log(userId);
+    // TODO 유저 상세 정보 페이지로 리다이렉션 필요
   };
 
   return (
@@ -87,22 +86,17 @@ export const StudyDetailCard = ({
         anchorEl={anchorEl}
         open={!!anchorEl}
         onClose={handleClose}
-        MenuListProps={{
-          "aria-labelledby": "basic-button",
-        }}
       >
         {member.map((user) => {
           return (
-            <MenuItem
+            <S.StyledMenuItem
               onClick={() => {
                 userOnClick(user.userId);
               }}
             >
-              <S.userItem>
-                <Avatar key={user.userId} src={user.img} />
-                <span>test</span>
-              </S.userItem>
-            </MenuItem>
+              <Avatar key={user.userId} src={user.img} />
+              <span>{user.name}</span>
+            </S.StyledMenuItem>
           );
         })}
       </Menu>

--- a/components/StudyDetailCard/StudyDetailCard.tsx
+++ b/components/StudyDetailCard/StudyDetailCard.tsx
@@ -1,0 +1,71 @@
+import Image from "next/image";
+import { useState } from "react";
+import { AvatarGroup, Avatar } from '@mui/material';
+import { StudyState } from "./StudyState";
+import * as S from "./style";
+
+interface StudyDetailProps {
+  size: number;
+  src: string;
+  title: string;
+  gatherStartDate: Date;
+  gatherEndDate: Date;
+  studyStartDate: Date;
+  studyEndDate: Date;
+  maxParticipant: number;
+  currentParticipant: number;
+}
+
+// TODO Image => future Image로 수정해야 함
+export const StudyDetailCard = ({
+  size = 128,
+  src = "https://picsum.photos/200",
+  title = "스터디 제목",
+  gatherStartDate = new Date(2022, 7, 1),
+  gatherEndDate = new Date(2022, 7, 31),
+  studyStartDate = new Date(2022, 8, 1),
+  studyEndDate = new Date(2022, 8, 30),
+  maxParticipant = 16,
+  currentParticipant = 0,
+}: StudyDetailProps) => {
+  const getYYYYMMDD = (date: Date) => {
+    const yyyy = date.getFullYear();
+    const mm = date.getMonth();
+    const dd = date.getDate();
+
+    return `${yyyy}/${mm}/${dd}`;
+  };
+
+  const [isGathering, setIsGathering] = useState(true);
+
+  return (
+    <S.StudyDetailCard>
+      <S.ImageWrapper>
+        <div>북카드 컴포넌트 넣기</div>
+      </S.ImageWrapper>
+      <S.StudyInfoContainer>
+        <S.ResponsiveText fontSize={1.3}>{title}</S.ResponsiveText>
+        {isGathering && (
+          <S.ResponsiveText>
+            모집 인원 : {currentParticipant}/{maxParticipant}
+          </S.ResponsiveText>
+        )}
+        <S.ResponsiveText>
+          모집 기간 : {getYYYYMMDD(gatherStartDate)} -{" "}
+          {getYYYYMMDD(gatherEndDate)}
+        </S.ResponsiveText>
+        <S.ResponsiveText>
+          {" "}
+          진행 기간 : {getYYYYMMDD(studyStartDate)} -{" "}
+          {getYYYYMMDD(studyEndDate)}
+        </S.ResponsiveText>
+      </S.StudyInfoContainer>
+      <AvatarGroup max={2}>
+        <Avatar src="https://picsum.photos/200"/>
+        <Avatar src="https://picsum.photos/200"/>
+        <Avatar src="https://picsum.photos/200"/>
+      </AvatarGroup>
+      <StudyState studyState="gathering"/>
+    </S.StudyDetailCard>
+  );
+};

--- a/components/StudyDetailCard/StudyDetailCard.tsx
+++ b/components/StudyDetailCard/StudyDetailCard.tsx
@@ -1,12 +1,10 @@
 import { MouseEvent, useState } from "react";
-import { Avatar, Menu, Typography } from "@mui/material";
+import { Avatar, Menu } from "@mui/material";
 import { StudyState } from "./StudyState";
 import * as S from "./style";
 import type { User } from "../../types/userType";
 
 interface StudyDetailProps {
-  size: number;
-  src: string;
   title: string;
   gatherStartDate: Date;
   gatherEndDate: Date;
@@ -19,8 +17,6 @@ interface StudyDetailProps {
 
 // TODO Image => future Image로 수정해야 함
 export const StudyDetailCard = ({
-  size = 128,
-  src = "https://picsum.photos/200",
   title = "스터디 제목",
   gatherStartDate = new Date(2022, 12, 1),
   gatherEndDate = new Date(2022, 7, 31),
@@ -59,7 +55,7 @@ export const StudyDetailCard = ({
         <div>북카드 컴포넌트 넣기</div>
       </S.ImageWrapper>
       <S.StudyInfoContainer>
-        <Typography style={{ fontSize: "1.25rem" }}>{title}</Typography>
+        <S.StyledTypograph>{title}</S.StyledTypograph>
         {isGathering && (
           <S.ResponsiveText>
             모집 인원 : {currentParticipant}/{maxParticipant}

--- a/components/StudyDetailCard/StudyDetailCard.tsx
+++ b/components/StudyDetailCard/StudyDetailCard.tsx
@@ -76,11 +76,11 @@ export const StudyDetailCard = ({
         </S.ResponsiveText>
       </S.StudyInfoContainer>
 
-      <AvatarGroup max={2} onClick={handleClick} style={{ height: "100%" }}>
+      <S.StyledAvatarGroup max={2} onClick={handleClick}>
         {member.map((user) => (
           <Avatar key={user.userId} src={user.img} />
         ))}
-      </AvatarGroup>
+      </S.StyledAvatarGroup>
       <Menu
         id="basic-menu"
         anchorEl={anchorEl}

--- a/components/StudyDetailCard/StudyDetailCard.tsx
+++ b/components/StudyDetailCard/StudyDetailCard.tsx
@@ -1,5 +1,5 @@
 import { MouseEvent, useState } from "react";
-import { AvatarGroup, Avatar, Menu } from "@mui/material";
+import { Avatar, Menu, Typography } from "@mui/material";
 import { StudyState } from "./StudyState";
 import * as S from "./style";
 import type { User } from "../../types/userType";
@@ -22,7 +22,7 @@ export const StudyDetailCard = ({
   size = 128,
   src = "https://picsum.photos/200",
   title = "스터디 제목",
-  gatherStartDate = new Date(2022, 7, 1),
+  gatherStartDate = new Date(2022, 12, 1),
   gatherEndDate = new Date(2022, 7, 31),
   studyStartDate = new Date(2022, 8, 1),
   studyEndDate = new Date(2022, 8, 30),
@@ -42,7 +42,6 @@ export const StudyDetailCard = ({
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const handleClick = (event: MouseEvent<HTMLDivElement>) => {
-    console.log(event.currentTarget);
     setAnchorEl(event.currentTarget);
   };
 
@@ -60,7 +59,7 @@ export const StudyDetailCard = ({
         <div>북카드 컴포넌트 넣기</div>
       </S.ImageWrapper>
       <S.StudyInfoContainer>
-        <S.ResponsiveText fontSize={1.3}>{title}</S.ResponsiveText>
+        <Typography style={{ fontSize: "1.25rem" }}>{title}</Typography>
         {isGathering && (
           <S.ResponsiveText>
             모집 인원 : {currentParticipant}/{maxParticipant}
@@ -90,11 +89,12 @@ export const StudyDetailCard = ({
         {member.map((user) => {
           return (
             <S.StyledMenuItem
+              key={user.userId}
               onClick={() => {
                 userOnClick(user.userId);
               }}
             >
-              <Avatar key={user.userId} src={user.img} />
+              <Avatar src={user.img} />
               <span>{user.name}</span>
             </S.StyledMenuItem>
           );

--- a/components/StudyDetailCard/StudyDetailCard.tsx
+++ b/components/StudyDetailCard/StudyDetailCard.tsx
@@ -3,13 +3,14 @@ import { Avatar, Menu } from "@mui/material";
 import { StudyState } from "./StudyState";
 import * as S from "./style";
 import type { User } from "../../types/userType";
+import { selectStudyState } from "./helper";
 
 interface StudyDetailProps {
   title: string;
-  gatherStartDate: Date;
-  gatherEndDate: Date;
-  studyStartDate: Date;
-  studyEndDate: Date;
+  gatherStartDate: string;
+  gatherEndDate: string;
+  studyStartDate: string;
+  studyEndDate: string;
   maxParticipant: number;
   currentParticipant: number;
   member: User[];
@@ -18,23 +19,20 @@ interface StudyDetailProps {
 // TODO Image => future Image로 수정해야 함
 export const StudyDetailCard = ({
   title = "스터디 제목",
-  gatherStartDate = new Date(2022, 12, 1),
-  gatherEndDate = new Date(2022, 7, 31),
-  studyStartDate = new Date(2022, 8, 1),
-  studyEndDate = new Date(2022, 8, 30),
+  gatherStartDate = "2022/6/30",
+  gatherEndDate = "2022/7/30",
+  studyStartDate = "2022/7/2",
+  studyEndDate = "2022/9/2",
   maxParticipant = 16,
   currentParticipant = 0,
   member = [],
 }: StudyDetailProps) => {
-  const getYYYYMMDD = (date: Date) => {
-    const yyyy = date.getFullYear();
-    const mm = date.getMonth();
-    const dd = date.getDate();
-
-    return `${yyyy}/${mm}/${dd}`;
-  };
-
-  const [isGathering, setIsGathering] = useState(true);
+  const studyState = selectStudyState(
+    gatherEndDate,
+    studyStartDate,
+    studyEndDate
+  );
+  console.log(studyState);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const handleAvatarListClick = (event: MouseEvent<HTMLDivElement>) => {
@@ -56,18 +54,16 @@ export const StudyDetailCard = ({
       </S.ImageWrapper>
       <S.StudyInfoContainer>
         <S.StyledTypograph>{title}</S.StyledTypograph>
-        {isGathering && (
+        {studyState === "recruiting" && (
           <S.ResponsiveText>
             모집 인원 : {currentParticipant}/{maxParticipant}
           </S.ResponsiveText>
         )}
         <S.ResponsiveText>
-          모집 기간 : {getYYYYMMDD(gatherStartDate)} -{" "}
-          {getYYYYMMDD(gatherEndDate)}
+          모집 기간 : {`${gatherStartDate} - ${gatherEndDate}`}
         </S.ResponsiveText>
         <S.ResponsiveText>
-          진행 기간 : {getYYYYMMDD(studyStartDate)} -{" "}
-          {getYYYYMMDD(studyEndDate)}
+          진행 기간 : {`${studyStartDate} - ${studyEndDate}`}
         </S.ResponsiveText>
       </S.StudyInfoContainer>
 
@@ -96,7 +92,7 @@ export const StudyDetailCard = ({
           );
         })}
       </Menu>
-      <StudyState studyState="recruiting" />
+      {studyState !== "done" && <StudyState studyState={studyState} />}
     </S.StudyDetailCard>
   );
 };

--- a/components/StudyDetailCard/StudyDetailCard.tsx
+++ b/components/StudyDetailCard/StudyDetailCard.tsx
@@ -37,15 +37,15 @@ export const StudyDetailCard = ({
   const [isGathering, setIsGathering] = useState(true);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
-  const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+  const handleAvatarListClick = (event: MouseEvent<HTMLDivElement>) => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleClose = () => {
+  const handleAvatarListClose = () => {
     setAnchorEl(null);
   };
 
-  const userOnClick = (userId: string) => {
+  const handleUserClick = (userId: string) => {
     // TODO 유저 상세 정보 페이지로 리다이렉션 필요
   };
 
@@ -71,7 +71,7 @@ export const StudyDetailCard = ({
         </S.ResponsiveText>
       </S.StudyInfoContainer>
 
-      <S.StyledAvatarGroup max={2} onClick={handleClick}>
+      <S.StyledAvatarGroup max={2} onClick={handleAvatarListClick}>
         {member.map((user) => (
           <Avatar key={user.userId} src={user.img} />
         ))}
@@ -80,14 +80,14 @@ export const StudyDetailCard = ({
         id="basic-menu"
         anchorEl={anchorEl}
         open={!!anchorEl}
-        onClose={handleClose}
+        onClose={handleAvatarListClose}
       >
         {member.map((user) => {
           return (
             <S.StyledMenuItem
               key={user.userId}
               onClick={() => {
-                userOnClick(user.userId);
+                handleUserClick(user.userId);
               }}
             >
               <Avatar src={user.img} />

--- a/components/StudyDetailCard/StudyDetailCard.tsx
+++ b/components/StudyDetailCard/StudyDetailCard.tsx
@@ -1,8 +1,9 @@
 import Image from "next/image";
-import { useState } from "react";
-import { AvatarGroup, Avatar } from '@mui/material';
+import { MouseEvent, useState } from "react";
+import { AvatarGroup, Avatar, Menu, MenuItem } from "@mui/material";
 import { StudyState } from "./StudyState";
 import * as S from "./style";
+import type { User } from "../../types/userType";
 
 interface StudyDetailProps {
   size: number;
@@ -14,6 +15,7 @@ interface StudyDetailProps {
   studyEndDate: Date;
   maxParticipant: number;
   currentParticipant: number;
+  member: User[];
 }
 
 // TODO Image => future Image로 수정해야 함
@@ -27,6 +29,7 @@ export const StudyDetailCard = ({
   studyEndDate = new Date(2022, 8, 30),
   maxParticipant = 16,
   currentParticipant = 0,
+  member = [],
 }: StudyDetailProps) => {
   const getYYYYMMDD = (date: Date) => {
     const yyyy = date.getFullYear();
@@ -37,6 +40,20 @@ export const StudyDetailCard = ({
   };
 
   const [isGathering, setIsGathering] = useState(true);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+    console.log(event.currentTarget);
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const userOnClick = (userId: string) => {
+    // console.log(userId);
+  };
 
   return (
     <S.StudyDetailCard>
@@ -55,17 +72,41 @@ export const StudyDetailCard = ({
           {getYYYYMMDD(gatherEndDate)}
         </S.ResponsiveText>
         <S.ResponsiveText>
-          {" "}
           진행 기간 : {getYYYYMMDD(studyStartDate)} -{" "}
           {getYYYYMMDD(studyEndDate)}
         </S.ResponsiveText>
       </S.StudyInfoContainer>
-      <AvatarGroup max={2}>
-        <Avatar src="https://picsum.photos/200"/>
-        <Avatar src="https://picsum.photos/200"/>
-        <Avatar src="https://picsum.photos/200"/>
+
+      <AvatarGroup max={2} onClick={handleClick} style={{ height: "100%" }}>
+        {member.map((user) => (
+          <Avatar key={user.userId} src={user.img} />
+        ))}
       </AvatarGroup>
-      <StudyState studyState="gathering"/>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={!!anchorEl}
+        onClose={handleClose}
+        MenuListProps={{
+          "aria-labelledby": "basic-button",
+        }}
+      >
+        {member.map((user) => {
+          return (
+            <MenuItem
+              onClick={() => {
+                userOnClick(user.userId);
+              }}
+            >
+              <S.userItem>
+                <Avatar key={user.userId} src={user.img} />
+                <span>test</span>
+              </S.userItem>
+            </MenuItem>
+          );
+        })}
+      </Menu>
+      <StudyState studyState="recruiting" />
     </S.StudyDetailCard>
   );
 };

--- a/components/StudyDetailCard/StudyState/StudyState.stories.tsx
+++ b/components/StudyDetailCard/StudyState/StudyState.stories.tsx
@@ -1,0 +1,16 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { StudyState } from ".";
+
+export default {
+  title: "components/StudyState",
+  component: StudyState,
+} as ComponentMeta<typeof StudyState>;
+
+const Template: ComponentStory<typeof StudyState> = (args) => (
+  <StudyState {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  studyState: "gathering",
+};

--- a/components/StudyDetailCard/StudyState/StudyState.stories.tsx
+++ b/components/StudyDetailCard/StudyState/StudyState.stories.tsx
@@ -12,5 +12,5 @@ const Template: ComponentStory<typeof StudyState> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  studyState: "gathering",
+  studyState: "recruiting",
 };

--- a/components/StudyDetailCard/StudyState/StudyState.tsx
+++ b/components/StudyDetailCard/StudyState/StudyState.tsx
@@ -10,15 +10,15 @@ export const StudyState = ({ studyState }: StudyStateProps) => {
   }
 
   const studyStateColor: studyStateTypes = {
-    gathering: "green",
+    recruiting: "green",
     inProgress: "orange",
-    gatherFinished: "red",
+    finished: "red",
   };
 
   const studyStateText: studyStateTypes = {
-    gathering: "모집중",
+    recruiting: "모집중",
     inProgress: "진행중",
-    gatherFinished: "모집완료",
+    finished: "모집완료",
   };
   return (
     <S.StudyState color={studyStateColor[studyState]}>

--- a/components/StudyDetailCard/StudyState/StudyState.tsx
+++ b/components/StudyDetailCard/StudyState/StudyState.tsx
@@ -1,0 +1,28 @@
+import * as S from "./style";
+
+interface StudyStateProps {
+  studyState: string;
+}
+
+export const StudyState = ({ studyState }: StudyStateProps) => {
+  interface studyStateTypes {
+    [key: string]: string;
+  }
+
+  const studyStateColor: studyStateTypes = {
+    gathering: "green",
+    inProgress: "orange",
+    gatherFinished: "red",
+  };
+
+  const studyStateText: studyStateTypes = {
+    gathering: "모집중",
+    inProgress: "진행중",
+    gatherFinished: "모집완료",
+  };
+  return (
+    <S.StudyState color={studyStateColor[studyState]}>
+      {studyStateText[studyState]}
+    </S.StudyState>
+  );
+};

--- a/components/StudyDetailCard/StudyState/index.ts
+++ b/components/StudyDetailCard/StudyState/index.ts
@@ -1,0 +1,1 @@
+export { StudyState } from './StudyState';

--- a/components/StudyDetailCard/StudyState/style.tsx
+++ b/components/StudyDetailCard/StudyState/style.tsx
@@ -3,7 +3,8 @@ import styled from "@emotion/styled";
 interface StudyStateProps {
   color: string;
 }
-export const StudyState = styled.div`
+
+export const StudyState = styled.div<StudyStateProps>`
   min-width: 3rem;
   max-width: 3rem;
 

--- a/components/StudyDetailCard/StudyState/style.tsx
+++ b/components/StudyDetailCard/StudyState/style.tsx
@@ -11,6 +11,8 @@ export const StudyState = styled.div`
   max-height: 2rem;
   background-color: ${({ color }) => color};
 
+  padding: 0 0.5rem;
+
   color: white;
   border-radius: 0.25rem;
   position: absolute;

--- a/components/StudyDetailCard/StudyState/style.tsx
+++ b/components/StudyDetailCard/StudyState/style.tsx
@@ -1,0 +1,25 @@
+import styled from "@emotion/styled";
+
+interface StudyStateProps {
+  color: string;
+}
+export const StudyState = styled.div`
+  min-width: 3rem;
+  max-width: 3rem;
+
+  min-height: 2rem;
+  max-height: 2rem;
+  background-color: ${({ color }) => color};
+
+  color: white;
+  border-radius: 0.25rem;
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+
+  box-shadow: 8px 8px 8px -3px rgba(0, 0, 0, 0.1);
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/components/StudyDetailCard/StudyState/style.tsx
+++ b/components/StudyDetailCard/StudyState/style.tsx
@@ -6,7 +6,6 @@ interface StudyStateProps {
 
 export const StudyState = styled.div<StudyStateProps>`
   min-width: 3rem;
-  max-width: 3rem;
 
   min-height: 2rem;
   max-height: 2rem;

--- a/components/StudyDetailCard/helper.ts
+++ b/components/StudyDetailCard/helper.ts
@@ -1,0 +1,30 @@
+const isOverTime = (endDate: string) => {
+  if (Date.parse(endDate) - Date.now() < 0) return true;
+  return false;
+};
+
+const isStudying = (startDate: string, endDate: string) => {
+  return isOverTime(startDate) ? !isOverTime(endDate) : false;
+};
+
+const isStudyEnding = (endDate: string) => {
+  return isOverTime(endDate);
+};
+
+const isGathering = (endDate: string) => {
+  return !isOverTime(endDate);
+};
+
+//
+export const selectStudyState = (
+  gatherEndDate: string,
+  studyStartDate: string,
+  studyEndDate: string
+) => {
+  if (isStudyEnding(studyEndDate) && !isGathering(gatherEndDate)) return "done";
+  return isStudying(studyStartDate, studyEndDate)
+    ? "inProgress"
+    : isGathering(gatherEndDate)
+    ? "recruiting"
+    : "finished";
+};

--- a/components/StudyDetailCard/index.ts
+++ b/components/StudyDetailCard/index.ts
@@ -1,0 +1,1 @@
+export { StudyDetailCard } from './StudyDetailCard';

--- a/components/StudyDetailCard/style.tsx
+++ b/components/StudyDetailCard/style.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Card, MenuItem, AvatarGroup } from "@mui/material";
+import { Card, MenuItem, AvatarGroup, Typography } from "@mui/material";
 
 export const StudyDetailCard = styled(Card)`
   display: flex;
@@ -45,6 +45,10 @@ export const StyledMenuItem = styled(MenuItem)`
   & span {
     margin-left: 1rem;
   }
+`;
+
+export const StyledTypograph = styled(Typography)`
+  font-size: 1.25rem;
 `;
 
 interface ResponsiveTextProps {

--- a/components/StudyDetailCard/style.tsx
+++ b/components/StudyDetailCard/style.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Card, MenuItem } from "@mui/material";
+import { Card, Menu, MenuItem, AvatarGroup } from "@mui/material";
 
 export const StudyDetailCard = styled(Card)`
   display: flex;
@@ -32,7 +32,14 @@ export const StudyInfoContainer = styled.div`
   overflow: hidden;
 `;
 
-export const StyledAvatarGroup = styled.div``;
+export const StyledAvatarGroup = styled(AvatarGroup)`
+  height: 100%;
+
+  @media (max-width: 512px) {
+    width: 100%;
+    justify-content: flex-end;
+  }
+`;
 
 export const StyledMenuItem = styled(MenuItem)`
   & span {

--- a/components/StudyDetailCard/style.tsx
+++ b/components/StudyDetailCard/style.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
-import { Card } from "@mui/material";
-import Button from "@mui/material/Button";
+import { Card, MenuItem } from "@mui/material";
 
 export const StudyDetailCard = styled(Card)`
   display: flex;
@@ -33,8 +32,12 @@ export const StudyInfoContainer = styled.div`
   overflow: hidden;
 `;
 
-export const userItem = styled.div`
-  display: flex;
+export const StyledAvatarGroup = styled.div``;
+
+export const StyledMenuItem = styled(MenuItem)`
+  & span {
+    margin-left: 1rem;
+  }
 `;
 
 interface ResponsiveTextProps {

--- a/components/StudyDetailCard/style.tsx
+++ b/components/StudyDetailCard/style.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Card, Menu, MenuItem, AvatarGroup } from "@mui/material";
+import { Card, MenuItem, AvatarGroup } from "@mui/material";
 
 export const StudyDetailCard = styled(Card)`
   display: flex;
@@ -52,11 +52,6 @@ interface ResponsiveTextProps {
 }
 
 export const ResponsiveText = styled.div<ResponsiveTextProps>`
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
   padding: 0.5rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
   font-size: ${({ fontSize }) => `${fontSize}rem`};
 `;

--- a/components/StudyDetailCard/style.tsx
+++ b/components/StudyDetailCard/style.tsx
@@ -1,0 +1,48 @@
+import styled from "@emotion/styled";
+import { Card } from "@mui/material";
+import Button from "@mui/material/Button";
+
+export const StudyDetailCard = styled(Card)`
+  display: flex;
+  padding: 1rem;
+  flex-direction: row;
+  position: relative;
+  @media (max-width: 512px) {
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+`;
+
+export const ImageWrapper = styled.div`
+  flex-shrink: 0;
+  & span {
+    margin: 0;
+    padding: 0;
+    display: inline !important;
+  }
+  @media (max-width: 512px) {
+    box-shadow: -12px 17px 16px 3px rgba(0, 0, 0, 0.1),
+      13px 0px 15px 4px rgba(0, 0, 0, 0.1);
+  }
+`;
+
+export const StudyInfoContainer = styled.div`
+  width: 100%;
+  padding: 1rem;
+  overflow: hidden;
+`;
+
+interface ResponsiveTextProps {
+  fontSize?: number;
+}
+
+export const ResponsiveText = styled.div<ResponsiveTextProps>`
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  padding: 0.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: ${({ fontSize }) => `${fontSize}rem`};
+`;

--- a/components/StudyDetailCard/style.tsx
+++ b/components/StudyDetailCard/style.tsx
@@ -33,6 +33,10 @@ export const StudyInfoContainer = styled.div`
   overflow: hidden;
 `;
 
+export const userItem = styled.div`
+  display: flex;
+`;
+
 interface ResponsiveTextProps {
   fontSize?: number;
 }

--- a/types/userType.ts
+++ b/types/userType.ts
@@ -1,0 +1,7 @@
+export interface User {
+  userId: "string";
+  name: "string";
+  email: "string";
+  img: "string";
+}
+

--- a/types/userType.ts
+++ b/types/userType.ts
@@ -1,7 +1,6 @@
 export interface User {
-  userId: "string";
-  name: "string";
-  email: "string";
-  img: "string";
+  userId: string;
+  name: string;
+  email: string;
+  img: string;
 }
-


### PR DESCRIPTION
# 👩‍💻 요구 사항과 구현 내용
close #13 

## 요구사항
 스터디 상세정보와 스터디 모집페이지에서 쓰일 공통 컴포넌트 StudyDetailCard 구현
 아바타 그룹 클릭시, 스터디원 모달 렌더링
 각 유저 클릭시 상세정보로 이동
 
 ## 구현 내용
 - [x] 스터디 상세정보와 스터디 모집페이지에서 쓰일 공통 컴포넌트 StudyDetailCard 구현
 - [x] 아바타 그룹 클릭시, 스터디원 모달 렌더링
 - [x] 각 유저 클릭시 상세정보로 이동
 
✅ PR 포인트 & 궁금한 점

현재 StudyDetailCard 코드의 jsx부분이 굉장히 긴듯 한데 어떻게 더 가독성이 좋게 만들수 있을까요??

