### PR TITLE
#9/feat/layout topbar

### DIFF
--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { MouseEvent } from "react";
+import type { MouseEvent, FormEvent } from "react";
 import Toolbar from "@mui/material/Toolbar";
 import SearchIcon from "@mui/icons-material/Search";
 import Button from "@mui/material/Button";
@@ -7,6 +7,8 @@ import MenuItem from "@mui/material/MenuItem";
 import Avatar from "@mui/material/Avatar";
 import FolderIcon from "@mui/icons-material/Folder";
 import Typography from "@mui/material/Typography";
+import { useRouter } from "next/router";
+import Link from "next/link";
 import * as S from "./style";
 
 // TODO 사용자 정보 불러오기
@@ -19,6 +21,8 @@ const FAKE_STUDY_LIST = [
 ];
 
 export const Topbar = () => {
+  const router = useRouter();
+
   const [isLogin, setIsLogin] = useState(false);
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
@@ -39,24 +43,39 @@ export const Topbar = () => {
     setAnchorEl(null);
   };
 
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const target = e.target as Element;
+    const word = target.querySelector("input")?.value;
+
+    router.push({
+      pathname: `/layoutTest`,
+      query: { word },
+    });
+  };
+
   return (
     <S.StyledAppbar position="fixed">
       <Toolbar>
         {/* TODO 로고가 정해지면 로고 바꾸기 */}
         <S.LogoIcon />
         <S.LogoText variant="h6" noWrap>
-          책모이
+          <Link href="/">
+            <a href="{() => false}">책모이</a>
+          </Link>
         </S.LogoText>
         <S.SearchInputContainer className="SearchWrapper">
-          <S.SearchInput className="Search">
-            <S.SearchIconWrapper>
-              <SearchIcon />
-            </S.SearchIconWrapper>
-            <S.StyledInputBase
-              placeholder="책을 검색해주세요"
-              inputProps={{ "aria-label": "search" }}
-            />
-          </S.SearchInput>
+          <form onSubmit={handleSubmit}>
+            <S.SearchInput className="Search">
+              <S.SearchIconWrapper>
+                <SearchIcon />
+              </S.SearchIconWrapper>
+              <S.StyledInputBase
+                placeholder="책을 검색해주세요"
+                inputProps={{ "aria-label": "search" }}
+              />
+            </S.SearchInput>
+          </form>
         </S.SearchInputContainer>
         {/* TODO 로그인, 로그아웃 처리 필요 */}
         {isLogin ? (

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -3,9 +3,20 @@ import type { MouseEvent } from "react";
 import Toolbar from "@mui/material/Toolbar";
 import SearchIcon from "@mui/icons-material/Search";
 import Button from "@mui/material/Button";
-import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
+import Avatar from "@mui/material/Avatar";
+import FolderIcon from "@mui/icons-material/Folder";
+import Typography from "@mui/material/Typography";
 import * as S from "./style";
+
+// TODO 사용자 정보 불러오기
+const FAKE_USER_NAME = "고광필";
+const FAKE_STUDY_LIST = [
+  { id: 1, title: "이름이 매우매우 매우 매우 매우 매우 긴 스터디" },
+  // { id: 1, title: "일이삼사오육칠팔구" },
+  { id: 2, title: "스터디 2" },
+  { id: 3, title: "스터디 3" },
+];
 
 export const Topbar = () => {
   const [isLogin, setIsLogin] = useState(false);
@@ -53,7 +64,7 @@ export const Topbar = () => {
             <Button variant="contained" onClick={handleOpen}>
               프로필
             </Button>
-            <Menu
+            <S.StyledMenu
               anchorEl={anchorEl}
               open={!!anchorEl}
               onClose={handleClose}
@@ -61,10 +72,24 @@ export const Topbar = () => {
                 "aria-labelledby": "basic-button",
               }}
             >
-              <MenuItem onClick={handleClose}>Profile</MenuItem>
-              <MenuItem onClick={handleClose}>My account</MenuItem>
-              <MenuItem onClick={handleLogout}>Logout</MenuItem>
-            </Menu>
+              <S.AvatarWrapper>
+                <Avatar>
+                  <FolderIcon />
+                </Avatar>
+                {FAKE_USER_NAME}
+              </S.AvatarWrapper>
+              <S.StyledDivider />
+              {FAKE_STUDY_LIST.map(({ id, title }) => (
+                <MenuItem onClick={handleClose} key={id}>
+                  <Typography noWrap>{title}</Typography>
+                </MenuItem>
+              ))}
+              <S.LogoutButtonWrapper>
+                <Button variant="contained" size="small" onClick={handleLogout}>
+                  로그아웃
+                </Button>
+              </S.LogoutButtonWrapper>
+            </S.StyledMenu>
           </>
         ) : (
           <Button variant="contained" onClick={handleLogin}>

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -1,10 +1,32 @@
-import * as React from "react";
+import { useState } from "react";
+import type { MouseEvent } from "react";
 import Toolbar from "@mui/material/Toolbar";
 import SearchIcon from "@mui/icons-material/Search";
 import Button from "@mui/material/Button";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
 import * as S from "./style";
 
 export const Topbar = () => {
+  const [isLogin, setIsLogin] = useState(false);
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  const handleLogin = () => {
+    setIsLogin(true);
+  };
+
+  const handleLogout = () => {
+    setIsLogin(false);
+  };
+
+  const handleOpen = (event: MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
   return (
     <S.StyledAppbar position="fixed">
       <Toolbar>
@@ -23,7 +45,29 @@ export const Topbar = () => {
             />
           </S.Search>
         </S.SearchWrapper>
-        <Button variant="contained">로그인</Button>
+        {isLogin ? (
+          <>
+            <Button variant="contained" onClick={handleOpen}>
+              프로필
+            </Button>
+            <Menu
+              anchorEl={anchorEl}
+              open={!!anchorEl}
+              onClose={handleClose}
+              MenuListProps={{
+                "aria-labelledby": "basic-button",
+              }}
+            >
+              <MenuItem onClick={handleClose}>Profile</MenuItem>
+              <MenuItem onClick={handleClose}>My account</MenuItem>
+              <MenuItem onClick={handleLogout}>Logout</MenuItem>
+            </Menu>
+          </>
+        ) : (
+          <Button variant="contained" onClick={handleLogin}>
+            로그인
+          </Button>
+        )}
       </Toolbar>
     </S.StyledAppbar>
   );

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -1,24 +1,14 @@
 import { useRef, useState } from "react";
-import type { MouseEvent, FormEvent } from "react";
-import Toolbar from "@mui/material/Toolbar";
+import type { FormEvent } from "react";
+import { Toolbar, Button } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
-import Button from "@mui/material/Button";
-import MenuItem from "@mui/material/MenuItem";
-import Avatar from "@mui/material/Avatar";
-import FolderIcon from "@mui/icons-material/Folder";
-import Typography from "@mui/material/Typography";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import * as S from "./style";
+import { UserProfile } from "./UserProfile";
 
 // TODO 사용자 정보 불러오기
-const FAKE_USER_NAME = "고광필";
-const FAKE_STUDY_LIST = [
-  { id: 1, title: "이름이 매우매우 매우 매우 매우 매우 긴 스터디" },
-  // { id: 1, title: "일이삼사오육칠팔구" },
-  { id: 2, title: "스터디 2" },
-  { id: 3, title: "스터디 3" },
-];
+
 const FAKE_URL = "/layoutTest";
 const FAKE_QUERY_SIZE = 6;
 
@@ -27,8 +17,8 @@ export const Topbar = () => {
 
   const inputRef = useRef<HTMLInputElement>(null);
   const inputDefaultValue = useRef("");
-
   const isClientWindow = typeof window !== "undefined";
+
   if (isClientWindow)
     if (window.location.pathname === FAKE_URL) {
       // TODO FAKE_URL 수정 시 FAKE_QUERY_SIZE 수정
@@ -42,7 +32,6 @@ export const Topbar = () => {
     } else if (inputRef.current) inputRef.current.value = "";
 
   const [isLogin, setIsLogin] = useState(false);
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
   const handleLogin = () => {
     setIsLogin(true);
@@ -50,15 +39,6 @@ export const Topbar = () => {
 
   const handleLogout = () => {
     setIsLogin(false);
-    setAnchorEl(null);
-  };
-
-  const handleOpen = (event: MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
   };
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
@@ -105,37 +85,7 @@ export const Topbar = () => {
         </S.SearchInputContainer>
         {/* TODO 로그인, 로그아웃 처리 필요 */}
         {isLogin ? (
-          <>
-            <Button variant="contained" onClick={handleOpen}>
-              프로필
-            </Button>
-            <S.StyledMenu
-              anchorEl={anchorEl}
-              open={!!anchorEl}
-              onClose={handleClose}
-              MenuListProps={{
-                "aria-labelledby": "basic-button",
-              }}
-            >
-              <S.AvatarWrapper>
-                <Avatar>
-                  <FolderIcon />
-                </Avatar>
-                {FAKE_USER_NAME}
-              </S.AvatarWrapper>
-              <S.StyledDivider />
-              {FAKE_STUDY_LIST.map(({ id, title }) => (
-                <MenuItem onClick={handleClose} key={id}>
-                  <Typography noWrap>{title}</Typography>
-                </MenuItem>
-              ))}
-              <S.LogoutButtonWrapper>
-                <Button variant="contained" size="small" onClick={handleLogout}>
-                  로그아웃
-                </Button>
-              </S.LogoutButtonWrapper>
-            </S.StyledMenu>
-          </>
+          <UserProfile handleLogout={handleLogout} />
         ) : (
           <Button variant="contained" onClick={handleLogin}>
             로그인

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { MouseEvent, FormEvent } from "react";
 import Toolbar from "@mui/material/Toolbar";
 import SearchIcon from "@mui/icons-material/Search";
@@ -19,9 +19,24 @@ const FAKE_STUDY_LIST = [
   { id: 2, title: "스터디 2" },
   { id: 3, title: "스터디 3" },
 ];
+const FAKE_URL = "/layoutTest";
+const FAKE_QUERY_SIZE = 6;
 
 export const Topbar = () => {
   const router = useRouter();
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const inputDefaultValue = useRef("");
+
+  const isClientWindow = typeof window !== "undefined";
+  if (isClientWindow)
+    if (window.location.pathname === FAKE_URL) {
+      // TODO FAKE_URL 수정 시 FAKE_QUERY_SIZE 수정
+      const defaultInitValue = decodeURI(window.location.search).slice(
+        FAKE_QUERY_SIZE
+      );
+      inputDefaultValue.current = defaultInitValue;
+    } else if (inputRef.current) inputRef.current.value = "";
 
   const [isLogin, setIsLogin] = useState(false);
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
@@ -73,6 +88,8 @@ export const Topbar = () => {
               <S.StyledInputBase
                 placeholder="책을 검색해주세요"
                 inputProps={{ "aria-label": "search" }}
+                defaultValue={inputDefaultValue.current}
+                inputRef={inputRef}
               />
             </S.SearchInput>
           </form>

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -32,10 +32,13 @@ export const Topbar = () => {
   if (isClientWindow)
     if (window.location.pathname === FAKE_URL) {
       // TODO FAKE_URL 수정 시 FAKE_QUERY_SIZE 수정
-      const defaultInitValue = decodeURI(window.location.search).slice(
-        FAKE_QUERY_SIZE
-      );
-      inputDefaultValue.current = defaultInitValue;
+      const urlWord = window.location.search
+        .slice(FAKE_QUERY_SIZE)
+        .replaceAll("+", " ")
+        .trim();
+      inputDefaultValue.current = decodeURIComponent(urlWord);
+      if (inputRef.current)
+        inputRef.current.value = decodeURIComponent(urlWord);
     } else if (inputRef.current) inputRef.current.value = "";
 
   const [isLogin, setIsLogin] = useState(false);
@@ -61,7 +64,13 @@ export const Topbar = () => {
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const target = e.target as Element;
-    const word = target.querySelector("input")?.value;
+    const word = target.querySelector("input")?.value.trim();
+
+    if (!word) {
+      // TODO alert 통일해서 추가하기
+      alert("검색 값을 입력해주세요");
+      return;
+    }
 
     router.push({
       pathname: `/layoutTest`,

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import AppBar from "@mui/material/AppBar";
+import Toolbar from "@mui/material/Toolbar";
+import AutoStoriesIcon from "@mui/icons-material/AutoStories";
+import * as S from "./style";
+
+export const Topbar = () => {
+  return (
+    <AppBar position="fixed" sx={{ backgroundColor: "green" }}>
+      <Toolbar>
+        <AutoStoriesIcon sx={{ display: { xs: "none", md: "flex" }, mr: 1 }} />
+        <S.LogoText variant="h6" noWrap>
+          책모이
+        </S.LogoText>
+      </Toolbar>
+    </AppBar>
+  );
+};

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -17,6 +17,7 @@ export const Topbar = () => {
 
   const handleLogout = () => {
     setIsLogin(false);
+    setAnchorEl(null);
   };
 
   const handleOpen = (event: MouseEvent<HTMLButtonElement>) => {
@@ -46,9 +47,9 @@ export const Topbar = () => {
             />
           </S.Search>
         </S.SearchWrapper>
+        {/* TODO 로그인, 로그아웃 처리 필요 */}
         {isLogin ? (
           <>
-            {/* FIXME 로그아웃하고 로그인하면 에러 발생 */}
             <Button variant="contained" onClick={handleOpen}>
               프로필
             </Button>

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -30,6 +30,7 @@ export const Topbar = () => {
   return (
     <S.StyledAppbar position="fixed">
       <Toolbar>
+        {/* TODO 로고가 정해지면 로고 바꾸기 */}
         <S.LogoIcon />
         <S.LogoText variant="h6" noWrap>
           책모이
@@ -47,6 +48,7 @@ export const Topbar = () => {
         </S.SearchWrapper>
         {isLogin ? (
           <>
+            {/* FIXME 로그아웃하고 로그인하면 에러 발생 */}
             <Button variant="contained" onClick={handleOpen}>
               프로필
             </Button>

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -1,17 +1,30 @@
 import * as React from "react";
 import AppBar from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
-import AutoStoriesIcon from "@mui/icons-material/AutoStories";
+import SearchIcon from "@mui/icons-material/Search";
+import Button from "@mui/material/Button";
 import * as S from "./style";
 
 export const Topbar = () => {
   return (
     <AppBar position="fixed" sx={{ backgroundColor: "green" }}>
       <Toolbar>
-        <AutoStoriesIcon />
+        <S.LogoIcon />
         <S.LogoText variant="h6" noWrap>
           책모이
         </S.LogoText>
+        <S.SearchWrapper>
+          <S.Search>
+            <S.SearchIconWrapper>
+              <SearchIcon />
+            </S.SearchIconWrapper>
+            <S.StyledInputBase
+              placeholder="책을 검색해주세요"
+              inputProps={{ "aria-label": "search" }}
+            />
+          </S.Search>
+        </S.SearchWrapper>
+        <Button variant="contained">로그인</Button>
       </Toolbar>
     </AppBar>
   );

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -47,8 +47,8 @@ export const Topbar = () => {
         <S.LogoText variant="h6" noWrap>
           책모이
         </S.LogoText>
-        <S.SearchWrapper>
-          <S.Search>
+        <S.SearchInputContainer className="SearchWrapper">
+          <S.SearchInput className="Search">
             <S.SearchIconWrapper>
               <SearchIcon />
             </S.SearchIconWrapper>
@@ -56,8 +56,8 @@ export const Topbar = () => {
               placeholder="책을 검색해주세요"
               inputProps={{ "aria-label": "search" }}
             />
-          </S.Search>
-        </S.SearchWrapper>
+          </S.SearchInput>
+        </S.SearchInputContainer>
         {/* TODO 로그인, 로그아웃 처리 필요 */}
         {isLogin ? (
           <>

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -8,7 +8,7 @@ export const Topbar = () => {
   return (
     <AppBar position="fixed" sx={{ backgroundColor: "green" }}>
       <Toolbar>
-        <AutoStoriesIcon sx={{ display: { xs: "none", md: "flex" }, mr: 1 }} />
+        <AutoStoriesIcon />
         <S.LogoText variant="h6" noWrap>
           책모이
         </S.LogoText>

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import AppBar from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
 import SearchIcon from "@mui/icons-material/Search";
 import Button from "@mui/material/Button";
@@ -7,7 +6,7 @@ import * as S from "./style";
 
 export const Topbar = () => {
   return (
-    <AppBar position="fixed" sx={{ backgroundColor: "green" }}>
+    <S.StyledAppbar position="fixed">
       <Toolbar>
         <S.LogoIcon />
         <S.LogoText variant="h6" noWrap>
@@ -26,6 +25,6 @@ export const Topbar = () => {
         </S.SearchWrapper>
         <Button variant="contained">로그인</Button>
       </Toolbar>
-    </AppBar>
+    </S.StyledAppbar>
   );
 };

--- a/features/Topbar/UserProfile/UserProfile.tsx
+++ b/features/Topbar/UserProfile/UserProfile.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import type { MouseEvent } from "react";
+import { Avatar, MenuItem, Typography, Button } from "@mui/material";
+import FolderIcon from "@mui/icons-material/Folder";
+import * as S from "./style";
+
+interface UserProfileProps {
+  handleLogout: () => void;
+}
+
+// TODO Context API 추가 후에 로그아웃은 내려받지 않도록 수정하기
+export const UserProfile = ({ handleLogout }: UserProfileProps) => {
+  const FAKE_USER_NAME = "고광필";
+  const FAKE_USER_EMAIL = "abcdefghi@naver.com";
+  const FAKE_STUDY_LIST = [
+    { id: 1, title: "이름이 매우매우 매우 매우 매우 매우 긴 스터디" },
+    { id: 2, title: "스터디 2" },
+    { id: 3, title: "스터디 3" },
+  ];
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  const handleOpen = (event: MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const clickLogoutButton = () => {
+    handleLogout();
+  };
+
+  return (
+    <>
+      <Button variant="contained" onClick={handleOpen}>
+        프로필
+      </Button>
+      <S.StyledMenu
+        anchorEl={anchorEl}
+        open={!!anchorEl}
+        onClose={handleClose}
+        MenuListProps={{
+          "aria-labelledby": "basic-button",
+        }}
+      >
+        <S.AvatarWrapper>
+          <Avatar>
+            <FolderIcon />
+          </Avatar>
+          <S.StyledUserInfo>
+            <span>{FAKE_USER_NAME}</span>
+            <span>{FAKE_USER_EMAIL}</span>
+          </S.StyledUserInfo>
+        </S.AvatarWrapper>
+        <S.StyledDivider />
+        {FAKE_STUDY_LIST.map(({ id, title }) => (
+          <MenuItem onClick={handleClose} key={id}>
+            <Typography noWrap>{title}</Typography>
+          </MenuItem>
+        ))}
+        <S.StyledDivider />
+        <S.LogoutButtonWrapper>
+          <Button variant="contained" size="small" onClick={clickLogoutButton}>
+            로그아웃
+          </Button>
+        </S.LogoutButtonWrapper>
+      </S.StyledMenu>
+    </>
+  );
+};

--- a/features/Topbar/UserProfile/index.ts
+++ b/features/Topbar/UserProfile/index.ts
@@ -1,0 +1,1 @@
+export { UserProfile } from "./UserProfile";

--- a/features/Topbar/UserProfile/style.tsx
+++ b/features/Topbar/UserProfile/style.tsx
@@ -1,0 +1,38 @@
+import { styled } from "@mui/material/styles";
+import { Menu, Divider } from "@mui/material";
+
+export const StyledMenu = styled(Menu)(() => ({
+  "& ul": {
+    minWidth: "10rem",
+    maxWidth: "20rem",
+  },
+}));
+
+export const AvatarWrapper = styled("div")(() => ({
+  display: "flex",
+  padding: "0.5rem 1rem",
+  alignItems: "center",
+  gap: "1rem",
+  width: "fit-content",
+  fontSize: "1.2rem",
+}));
+
+export const StyledUserInfo = styled("div")(() => ({
+  display: "flex",
+  flexDirection: "column",
+
+  "& span:last-child": {
+    fontSize: "0.5rem",
+  },
+}));
+
+export const StyledDivider = styled(Divider)(() => ({
+  textAlign: "center",
+  margin: "0.5rem 1rem",
+}));
+
+export const LogoutButtonWrapper = styled("div")(() => ({
+  display: "flex",
+  justifyContent: "end",
+  paddingRight: "1rem",
+}));

--- a/features/Topbar/index.ts
+++ b/features/Topbar/index.ts
@@ -1,0 +1,1 @@
+export { Topbar } from "./Topbar";

--- a/features/Topbar/style.tsx
+++ b/features/Topbar/style.tsx
@@ -3,8 +3,6 @@ import Typography from "@mui/material/Typography";
 import InputBase from "@mui/material/InputBase";
 import AutoStoriesIcon from "@mui/icons-material/AutoStories";
 import AppBar from "@mui/material/AppBar";
-import Divider from "@mui/material/Divider";
-import Menu from "@mui/material/Menu";
 
 export const StyledAppbar = styled(AppBar)(() => ({
   backgroundColor: "green",
@@ -78,31 +76,4 @@ export const StyledInputBase = styled(InputBase)(({ theme }) => ({
       },
     },
   },
-}));
-
-export const AvatarWrapper = styled("div")(() => ({
-  display: "flex",
-  alignItems: "center",
-  gap: "0.5rem",
-  margin: "auto",
-  width: "fit-content",
-}));
-
-export const StyledDivider = styled(Divider)(() => ({
-  width: "80%",
-  textAlign: "center",
-  margin: "0.5rem auto",
-}));
-
-export const StyledMenu = styled(Menu)(() => ({
-  "& ul": {
-    minWidth: "10rem",
-    maxWidth: "20rem",
-  },
-}));
-
-export const LogoutButtonWrapper = styled("div")(() => ({
-  display: "flex",
-  justifyContent: "end",
-  paddingRight: "1rem",
 }));

--- a/features/Topbar/style.tsx
+++ b/features/Topbar/style.tsx
@@ -3,6 +3,8 @@ import Typography from "@mui/material/Typography";
 import InputBase from "@mui/material/InputBase";
 import AutoStoriesIcon from "@mui/icons-material/AutoStories";
 import AppBar from "@mui/material/AppBar";
+import Divider from "@mui/material/Divider";
+import Menu from "@mui/material/Menu";
 
 export const StyledAppbar = styled(AppBar)(() => ({
   backgroundColor: "green",
@@ -76,4 +78,31 @@ export const StyledInputBase = styled(InputBase)(({ theme }) => ({
       },
     },
   },
+}));
+
+export const AvatarWrapper = styled("div")(() => ({
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+  margin: "auto",
+  width: "fit-content",
+}));
+
+export const StyledDivider = styled(Divider)(() => ({
+  width: "80%",
+  textAlign: "center",
+  margin: "0.5rem auto",
+}));
+
+export const StyledMenu = styled(Menu)(() => ({
+  "& ul": {
+    minWidth: "10rem",
+    maxWidth: "20rem",
+  },
+}));
+
+export const LogoutButtonWrapper = styled("div")(() => ({
+  display: "flex",
+  justifyContent: "end",
+  paddingRight: "1rem",
 }));

--- a/features/Topbar/style.tsx
+++ b/features/Topbar/style.tsx
@@ -1,0 +1,12 @@
+import { styled } from "@mui/material/styles";
+import { Typography } from "@mui/material";
+
+export const LogoText = styled(Typography)`
+  margin-right: 1rem;
+  display: flex;
+  font-family: monospace;
+  font-weight: 700;
+  letter-spacing: 0.3rem;
+  color: inherit;
+  text-decoration: none;
+`;

--- a/features/Topbar/style.tsx
+++ b/features/Topbar/style.tsx
@@ -2,6 +2,11 @@ import { styled, alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import InputBase from "@mui/material/InputBase";
 import AutoStoriesIcon from "@mui/icons-material/AutoStories";
+import AppBar from "@mui/material/AppBar";
+
+export const StyledAppbar = styled(AppBar)(() => ({
+  backgroundColor: "green",
+}));
 
 export const LogoIcon = styled(AutoStoriesIcon)(() => ({
   marginRight: "0.5rem",

--- a/features/Topbar/style.tsx
+++ b/features/Topbar/style.tsx
@@ -28,13 +28,13 @@ export const LogoText = styled(Typography)(({ theme }) => ({
   },
 }));
 
-export const SearchWrapper = styled("div")(() => ({
+export const SearchInputContainer = styled("div")(() => ({
   flexGrow: 1,
   display: "flex",
   justifyContent: "center",
 }));
 
-export const Search = styled("div")(({ theme }) => ({
+export const SearchInput = styled("div")(({ theme }) => ({
   position: "relative",
   borderRadius: theme.shape.borderRadius,
   backgroundColor: alpha(theme.palette.common.white, 0.15),

--- a/features/Topbar/style.tsx
+++ b/features/Topbar/style.tsx
@@ -2,7 +2,8 @@ import { styled } from "@mui/material/styles";
 import { Typography } from "@mui/material";
 
 export const LogoText = styled(Typography)`
-  margin-right: 1rem;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
   display: flex;
   font-family: monospace;
   font-weight: 700;

--- a/features/Topbar/style.tsx
+++ b/features/Topbar/style.tsx
@@ -1,13 +1,74 @@
-import { styled } from "@mui/material/styles";
-import { Typography } from "@mui/material";
+import { styled, alpha } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import InputBase from "@mui/material/InputBase";
+import AutoStoriesIcon from "@mui/icons-material/AutoStories";
 
-export const LogoText = styled(Typography)`
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
-  display: flex;
-  font-family: monospace;
-  font-weight: 700;
-  letter-spacing: 0.3rem;
-  color: inherit;
-  text-decoration: none;
-`;
+export const LogoIcon = styled(AutoStoriesIcon)(() => ({
+  marginRight: "0.5rem",
+}));
+
+export const LogoText = styled(Typography)(({ theme }) => ({
+  marginRight: "0.5rem",
+  display: "flex",
+  fontFamily: "monospace",
+  fontWeight: "700",
+  letterSpacing: "0.3rem",
+  color: "inherit",
+  textDecoration: "none",
+
+  [theme.breakpoints.down("sm")]: {
+    display: "none",
+  },
+}));
+
+export const SearchWrapper = styled("div")(() => ({
+  flexGrow: 1,
+  display: "flex",
+  justifyContent: "center",
+}));
+
+export const Search = styled("div")(({ theme }) => ({
+  position: "relative",
+  borderRadius: theme.shape.borderRadius,
+  backgroundColor: alpha(theme.palette.common.white, 0.15),
+  marginLeft: 0,
+  width: "100%",
+
+  "&:hover": {
+    backgroundColor: alpha(theme.palette.common.white, 0.25),
+  },
+
+  [theme.breakpoints.up("sm")]: {
+    marginLeft: theme.spacing(1),
+    width: "auto",
+  },
+}));
+
+export const SearchIconWrapper = styled("div")(({ theme }) => ({
+  padding: theme.spacing(0, 2),
+  height: "100%",
+  position: "absolute",
+  pointerEvents: "none",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+}));
+
+export const StyledInputBase = styled(InputBase)(({ theme }) => ({
+  color: "inherit",
+
+  "& .MuiInputBase-input": {
+    padding: theme.spacing(1, 1, 1, 0),
+    paddingLeft: `calc(1em + ${theme.spacing(4)})`,
+    transition: theme.transitions.create("width"),
+    width: "100%",
+
+    [theme.breakpoints.up("sm")]: {
+      width: "20rem",
+
+      "&:focus": {
+        width: "30rem",
+      },
+    },
+  },
+}));

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,17 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
-}
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;
+
+module.exports = {
+  experimental: {
+    images: {
+      allowFutureImage: true,
+    },
+  },
+  images: {
+    domains: ["i.picsum.photos"],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
+    "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.2",
     "next": "12.2.3",
     "react": "18.2.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,18 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
+import { Topbar } from "../features/Topbar";
+import * as S from "./style";
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Topbar />
+      <S.ContentContainer>
+        <Component {...pageProps} />
+      </S.ContentContainer>
+    </>
+  );
 };
 
 export default MyApp;

--- a/pages/layoutTest/ContentWrapper.tsx
+++ b/pages/layoutTest/ContentWrapper.tsx
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+
+export const ContentContainer = styled.div`
+  margin: calc(64px + 4rem) 4rem 64px;
+`;
+
+export const ContentWrapper = styled.div`
+  border: solid 1px;
+  height: 1000px;
+`;

--- a/pages/layoutTest/index.tsx
+++ b/pages/layoutTest/index.tsx
@@ -28,7 +28,6 @@ const DummyBook = ({ word }: DummyProps) => {
 };
 
 const LayoutTestPage = () => {
-  // TODO 더미 데이터 만들어서 페이지네이션 만들기
   const displayBookCount = 8;
 
   const dummyArray = Array.from(new Array(100), (x, i) => `${i + 1}`);

--- a/pages/layoutTest/index.tsx
+++ b/pages/layoutTest/index.tsx
@@ -1,5 +1,7 @@
-import { useRouter } from "next/router";
 import Image from "next/future/image";
+import { useState, useEffect } from "react";
+import type { ChangeEvent } from "react";
+import Pagination from "@mui/material/Pagination";
 
 interface DummyProps {
   word: string | undefined | string[];
@@ -26,14 +28,57 @@ const DummyBook = ({ word }: DummyProps) => {
 };
 
 const LayoutTestPage = () => {
-  const router = useRouter();
-  const { word } = router.query;
   // TODO 더미 데이터 만들어서 페이지네이션 만들기
+  const displayBookCount = 8;
+
+  const dummyArray = Array.from(new Array(100), (x, i) => `${i + 1}`);
+  const lastPage = Math.ceil(dummyArray.length / displayBookCount);
+  const [page, setPage] = useState(1);
+  const [pageData, setPageData] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (page === lastPage)
+      setPageData(dummyArray.slice(displayBookCount * (page - 1)));
+    else
+      setPageData(
+        dummyArray.slice(
+          displayBookCount * (page - 1),
+          displayBookCount * (page - 1) + displayBookCount
+        )
+      );
+  }, [page]);
+
+  const handlePage = (e: ChangeEvent<unknown> | null, inputPage: number) => {
+    setPage(inputPage);
+  };
+
   return (
-    <div>
-      {word}
-      <DummyBook word={word} />
-    </div>
+    <>
+      <div>
+        <ul
+          style={{
+            listStyle: "none",
+            display: "grid",
+            gridTemplateRows: "1fr 1fr",
+            gridTemplateColumns: "1fr 1fr 1fr 1fr",
+          }}
+        >
+          {pageData.map((data) => (
+            <li key={Math.random()}>
+              <DummyBook word={data} />
+            </li>
+          ))}
+        </ul>
+      </div>
+      <Pagination
+        count={Math.ceil(dummyArray.length / 8)}
+        variant="outlined"
+        shape="rounded"
+        color="primary"
+        page={page}
+        onChange={handlePage}
+      />
+    </>
   );
 };
 

--- a/pages/layoutTest/index.tsx
+++ b/pages/layoutTest/index.tsx
@@ -1,15 +1,5 @@
-import { Topbar } from "../../features/Topbar";
-import { ContentContainer, ContentWrapper } from "./ContentWrapper";
-
 const LayoutTestPage = () => {
-  return (
-    <>
-      <Topbar />
-      <ContentContainer>
-        <ContentWrapper>TestPage Content</ContentWrapper>
-      </ContentContainer>
-    </>
-  );
+  return <div>TestPage</div>;
 };
 
 export default LayoutTestPage;

--- a/pages/layoutTest/index.tsx
+++ b/pages/layoutTest/index.tsx
@@ -1,0 +1,15 @@
+import { Topbar } from "../../features/Topbar";
+import { ContentContainer, ContentWrapper } from "./ContentWrapper";
+
+const LayoutTestPage = () => {
+  return (
+    <>
+      <Topbar />
+      <ContentContainer>
+        <ContentWrapper>TestPage Content</ContentWrapper>
+      </ContentContainer>
+    </>
+  );
+};
+
+export default LayoutTestPage;

--- a/pages/layoutTest/index.tsx
+++ b/pages/layoutTest/index.tsx
@@ -1,5 +1,40 @@
+import { useRouter } from "next/router";
+import Image from "next/future/image";
+
+interface DummyProps {
+  word: string | undefined | string[];
+}
+
+const DummyBook = ({ word }: DummyProps) => {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+      }}
+    >
+      <Image
+        src="https://i.picsum.photos/id/962/200/300.jpg?hmac=wvuv8EVOoNE5J3sBkBx-1wcVHNbgJ_Z1dS98YhnShjM"
+        width={300}
+        height={300}
+        alt="Test"
+      />
+      {word}
+    </div>
+  );
+};
+
 const LayoutTestPage = () => {
-  return <div>TestPage</div>;
+  const router = useRouter();
+  const { word } = router.query;
+  // TODO 더미 데이터 만들어서 페이지네이션 만들기
+  return (
+    <div>
+      {word}
+      <DummyBook word={word} />
+    </div>
+  );
 };
 
 export default LayoutTestPage;

--- a/pages/style.tsx
+++ b/pages/style.tsx
@@ -3,8 +3,3 @@ import styled from "@emotion/styled";
 export const ContentContainer = styled.div`
   margin: calc(64px + 4rem) 4rem 64px;
 `;
-
-export const ContentWrapper = styled.div`
-  border: solid 1px;
-  height: 1000px;
-`;

--- a/pages/style.tsx
+++ b/pages/style.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 
+// TODO 레이아웃 결정되면 수치 수정하기
 export const ContentContainer = styled.div`
   margin: calc(64px + 4rem) 4rem 64px;
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1493,6 +1493,13 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
+"@mui/icons-material@^5.8.4":
+  version "5.8.4"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.8.4.tgz#3f2907c9f8f5ce4d754cb8fb4b68b5a1abf4d095"
+  integrity sha512-9Z/vyj2szvEhGWDvb+gG875bOGm8b8rlHBKOD1+nA3PcgC3fV6W1AU6pfOorPeBfH2X4mb9Boe97vHvaSndQvA==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+
 "@mui/material@^5.9.2":
   version "5.9.2"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.9.2.tgz#2526c33568b4c785b0784b0714a8f613cd9dcd46"


### PR DESCRIPTION
# 👩‍💻 요구 사항과 구현 내용

#9 

## 요구 사항
- 상단 바는 좌측 로고 / 가운데 검색 / 우측 프로필로 이루어진다
- 좌측 로고를 누르면 홈으로 이동한다
- 가운데 검색을 하면 책 검색 페이지로 이동한다
- 우측 버튼은 비로그인 시 로그인 버튼이고, 로그인 시 프로필 버튼이다
  - 프로필 버튼을 클릭 시 사용자의 간단 프로필, 가입 스터디 목록, 로그아웃 버튼을 보여준다

## 구현 내용

- 모든 페이지에 들어갈 레이아웃인 상단 바를 개발했습니다
  - [x] 새로고침 방어
- 책 검색 페이지에 페이지네이션을 추가했습니다

## 이후 추가 사항

임시로 만든 더미 카드 대신 북카드를 사용할 예정입니다

## 기타

- input의 검색 값을 state로 관리하면 검색마다 렌더링이 발생하기 때문에 사용하지 않았습니다

- 새로고침 방어
  - 새로고침을 방어하기 위해 useEffect 안에 next router로 쿼리를 읽어서 사용했었는데
마운트 이후이다 보니 새로고침 시 아래 (구) 결과처럼 값이없다가 생기게 되어서 다소 부자연스러웠습니다
  - next router는 새로고침 시 undefined 이후 query를 인식했는데
window.location은 바로 url을 읽어올 수 있었습니다
window.location으로 검색 값을 읽어오면 url 인코딩이 되어 있어서 추가 디코딩 로직이 필요합니다
결과적으로는 아래 (신) 결과처럼 새로고침 시 전보다 더 깔끔한 동작이 가능합니다

![old새로고침](https://user-images.githubusercontent.com/50919342/181903569-0202c2f3-6bee-4fa2-a80e-8d788b159e83.gif)
(구) 결과

![new새로고침](https://user-images.githubusercontent.com/50919342/181903708-0b7c3a92-48b9-42de-93d3-4bf6c4bb1643.gif)
(신) 결과

