### PR TITLE
#8/feat/study card - 공통컴포넌트 'StudyCard' 구현

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,12 @@
+import * as NextImage from "next/image";
+
+const OriginalNextImage = NextImage.default;
+
+Object.defineProperty(NextImage, "default", {
+  configurable: true,
+  value: (props) => <OriginalNextImage {...props} unoptimized />,
+});
+
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {
@@ -6,4 +15,4 @@ export const parameters = {
       date: /Date$/,
     },
   },
-}
+};

--- a/components/StudyCard/StudyCard.stories.tsx
+++ b/components/StudyCard/StudyCard.stories.tsx
@@ -1,0 +1,14 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { StudyCard } from ".";
+
+export default {
+  title: "Components/StudyCard",
+  component: StudyCard,
+  argTypes: {},
+} as ComponentMeta<typeof StudyCard>;
+
+const Template: ComponentStory<typeof StudyCard> = (args) => {
+  return <StudyCard {...args} />;
+};
+
+export const Default = Template.bind({});

--- a/components/StudyCard/StudyCard.tsx
+++ b/components/StudyCard/StudyCard.tsx
@@ -1,0 +1,10 @@
+import Card from "@mui/material/Card";
+import * as S from "./style";
+
+interface TestProps {
+  string: string;
+}
+
+export const StudyCard = ({ string }: TestProps) => {
+  return <Card />;
+};

--- a/components/StudyCard/StudyCard.tsx
+++ b/components/StudyCard/StudyCard.tsx
@@ -26,14 +26,12 @@ export const StudyCard = ({
   currentParticipant = 0,
 }: StudyCardProps) => {
   return (
-    <S.StudyCard sx={{ textOverflow: "ellipsis", overflow: "hidden" }}>
+    <S.StudyCard>
       <S.ImageWrapper>
         <Image
-          layout="fixed"
           width={size}
           height={size * 1.5}
           src={src}
-          style={{ flexShrink: 0 }}
         />
       </S.ImageWrapper>
       <S.StudyInfoConatiner>

--- a/components/StudyCard/StudyCard.tsx
+++ b/components/StudyCard/StudyCard.tsx
@@ -1,10 +1,53 @@
-import Card from "@mui/material/Card";
+import Image from "next/image";
 import * as S from "./style";
 
-interface TestProps {
-  string: string;
+interface StudyCardProps {
+  size: number;
+  src: string;
+  title: string;
+  gatherStartDate: string;
+  gatherEndDate: string;
+  studyStartDate: string;
+  studyEndDate: string;
+  maxParticipant: number;
+  currentParticipant: number;
 }
 
-export const StudyCard = ({ string }: TestProps) => {
-  return <Card />;
+// TODO defaultValue 수정
+export const StudyCard = ({
+  size = 128,
+  src = "https://picsum.photos/200",
+  title = "스터디 제목",
+  gatherStartDate = new Date(2022, 8, 31).toString(),
+  gatherEndDate = new Date(2022, 8, 31).toString(),
+  studyStartDate = new Date(2022, 8, 31).toString(),
+  studyEndDate = new Date(2022, 8, 31).toString(),
+  maxParticipant = 16,
+  currentParticipant = 0,
+}: StudyCardProps) => {
+  return (
+    <S.StudyCard sx={{ textOverflow: "ellipsis", overflow: "hidden" }}>
+      <S.ImageWrapper>
+        <Image
+          layout="fixed"
+          width={size}
+          height={size * 1.5}
+          src={src}
+          style={{ flexShrink: 0 }}
+        />
+      </S.ImageWrapper>
+      <S.StudyInfoConatiner>
+        <S.ResponsiveText>스터디 제목 : {title}</S.ResponsiveText>
+        <S.ResponsiveText>
+          모집 기간 : {gatherStartDate} - {gatherEndDate}
+        </S.ResponsiveText>
+        <S.ResponsiveText>
+          모집 인원 : {currentParticipant}/{maxParticipant}
+        </S.ResponsiveText>
+        <S.ResponsiveText>
+          진행 기간 : {studyStartDate} - {studyEndDate}
+        </S.ResponsiveText>
+      </S.StudyInfoConatiner>
+    </S.StudyCard>
+  );
 };

--- a/components/StudyCard/StudyCard.tsx
+++ b/components/StudyCard/StudyCard.tsx
@@ -5,47 +5,50 @@ interface StudyCardProps {
   size: number;
   src: string;
   title: string;
-  gatherStartDate: string;
-  gatherEndDate: string;
-  studyStartDate: string;
-  studyEndDate: string;
+  gatherStartDate: Date;
+  gatherEndDate: Date;
+  studyStartDate: Date;
+  studyEndDate: Date;
   maxParticipant: number;
   currentParticipant: number;
 }
 
-// TODO defaultValue 수정
 export const StudyCard = ({
   size = 128,
   src = "https://picsum.photos/200",
   title = "스터디 제목",
-  gatherStartDate = new Date(2022, 8, 31).toString(),
-  gatherEndDate = new Date(2022, 8, 31).toString(),
-  studyStartDate = new Date(2022, 8, 31).toString(),
-  studyEndDate = new Date(2022, 8, 31).toString(),
+  gatherStartDate = new Date(2022, 7, 1),
+  gatherEndDate = new Date(2022, 7, 31),
+  studyStartDate = new Date(2022, 8, 1),
+  studyEndDate = new Date(2022, 8, 30),
   maxParticipant = 16,
   currentParticipant = 0,
 }: StudyCardProps) => {
+  const getYYYYMMDD = (date: Date) => {
+    const yyyy = date.getFullYear();
+    const mm = date.getMonth();
+    const dd = date.getDate();
+
+    return `${yyyy}/${mm}/${dd}`;
+  };
+
   return (
     <S.StudyCard>
       <S.ImageWrapper>
-        <Image
-          width={size}
-          height={size * 1.5}
-          src={src}
-        />
+        <Image width={size} height={size * 1.5} src={src} />
       </S.ImageWrapper>
       <S.StudyInfoConatiner>
-        <S.ResponsiveTextWrapper>
-          <S.ResponsiveText>{title}</S.ResponsiveText>
-        </S.ResponsiveTextWrapper>
-        <S.ResponsiveText>
-          모집 기간 : {gatherStartDate} - {gatherEndDate}
-        </S.ResponsiveText>
+        <S.ResponsiveText fontSize={1.2}>{title}</S.ResponsiveText>
         <S.ResponsiveText>
           모집 인원 : {currentParticipant}/{maxParticipant}
         </S.ResponsiveText>
         <S.ResponsiveText>
-          진행 기간 : {studyStartDate} - {studyEndDate}
+          모집 기간 : {getYYYYMMDD(gatherStartDate)} -{" "}
+          {getYYYYMMDD(gatherEndDate)}
+        </S.ResponsiveText>
+        <S.ResponsiveText>
+          진행 기간 : {getYYYYMMDD(studyStartDate)} -{" "}
+          {getYYYYMMDD(studyEndDate)}
         </S.ResponsiveText>
       </S.StudyInfoConatiner>
     </S.StudyCard>

--- a/components/StudyCard/StudyCard.tsx
+++ b/components/StudyCard/StudyCard.tsx
@@ -37,7 +37,9 @@ export const StudyCard = ({
         />
       </S.ImageWrapper>
       <S.StudyInfoConatiner>
-        <S.ResponsiveText>스터디 제목 : {title}</S.ResponsiveText>
+        <S.ResponsiveTextWrapper>
+          <S.ResponsiveText>{title}</S.ResponsiveText>
+        </S.ResponsiveTextWrapper>
         <S.ResponsiveText>
           모집 기간 : {gatherStartDate} - {gatherEndDate}
         </S.ResponsiveText>

--- a/components/StudyCard/index.ts
+++ b/components/StudyCard/index.ts
@@ -1,0 +1,1 @@
+export { StudyCard } from "./StudyCard";

--- a/components/StudyCard/style.tsx
+++ b/components/StudyCard/style.tsx
@@ -9,6 +9,10 @@ export const StudyCard = styled(Card)`
 
 export const ImageWrapper = styled.div`
   flex-shrink: 0;
+  @media (max-width: 512px) {
+    width: 0;
+    height: 0;
+  }
 `;
 
 export const StudyInfoConatiner = styled.div`
@@ -31,4 +35,7 @@ export const ResponsiveText = styled.div<ResponsiveTextProps>`
   text-overflow: ellipsis;
 
   font-size: ${({ fontSize }) => `${fontSize}rem`};
+  @media (max-width: 320px) {
+    font-size: 0.8rem;
+  }
 `;

--- a/components/StudyCard/style.tsx
+++ b/components/StudyCard/style.tsx
@@ -19,13 +19,16 @@ export const StudyInfoConatiner = styled.div`
   overflow: hidden;
 `;
 
-export const ResponsiveTextWrapper = styled.div`
-  font-size: 1.3rem;
-`;
-export const ResponsiveText = styled.div`
+interface ResponsiveTextProps {
+  fontSize?: number;
+}
+
+export const ResponsiveText = styled.div<ResponsiveTextProps>`
   padding: 0.5rem;
 
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  font-size: ${({ fontSize }) => `${fontSize}rem`};
 `;

--- a/components/StudyCard/style.tsx
+++ b/components/StudyCard/style.tsx
@@ -4,8 +4,6 @@ import { Card } from "@mui/material";
 export const StudyCard = styled(Card)`
   display: flex;
 
-  width: 100%;
-
   padding: 1rem;
 `;
 
@@ -13,24 +11,18 @@ export const ImageWrapper = styled.div`
   flex-shrink: 0;
 `;
 
-// TODO ellipsis 적용 안됨
 export const StudyInfoConatiner = styled.div`
-  display: block;
+  width: 100%;
 
   padding: 1rem;
 
-  flex-basis: 200px;
-
-  &:first-child {
-    font-size: 1.33rem;
-  }
+  overflow: hidden;
 `;
 
+export const ResponsiveTextWrapper = styled.div`
+  font-size: 1.3rem;
+`;
 export const ResponsiveText = styled.div`
-  width: 100%;
-
-  display: block;
-
   padding: 0.5rem;
 
   white-space: nowrap;

--- a/components/StudyCard/style.tsx
+++ b/components/StudyCard/style.tsx
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+
+interface StyledTestProps {
+  string: string;
+}
+
+export const StyledTest = styled.div<StyledTestProps>`
+  background-color: ${({ string }) => (string ? "black" : "yellow")};
+`;

--- a/components/StudyCard/style.tsx
+++ b/components/StudyCard/style.tsx
@@ -1,9 +1,39 @@
 import styled from "@emotion/styled";
+import { Card } from "@mui/material";
 
-interface StyledTestProps {
-  string: string;
-}
+export const StudyCard = styled(Card)`
+  display: flex;
 
-export const StyledTest = styled.div<StyledTestProps>`
-  background-color: ${({ string }) => (string ? "black" : "yellow")};
+  width: 100%;
+
+  padding: 1rem;
+`;
+
+export const ImageWrapper = styled.div`
+  flex-shrink: 0;
+`;
+
+// TODO ellipsis 적용 안됨
+export const StudyInfoConatiner = styled.div`
+  display: block;
+
+  padding: 1rem;
+
+  flex-basis: 200px;
+
+  &:first-child {
+    font-size: 1.33rem;
+  }
+`;
+
+export const ResponsiveText = styled.div`
+  width: 100%;
+
+  display: block;
+
+  padding: 0.5rem;
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@mui/material": "^5.9.2",
+    "hast": "^1.0.0",
     "next": "12.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6446,6 +6446,11 @@ hast-util-to-parse5@^6.0.0:
     xtend "^4.0.0"
     zwitch "^1.0.0"
 
+hast@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hast/-/hast-1.0.0.tgz#50615e6b2b0583e5608bc76c47029722f1e00607"
+  integrity sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA==
+
 hastscript@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-6.0.0.tgz#e8768d7eac56c3fdeac8a92830d58e811e5bf640"


### PR DESCRIPTION
#👩‍💻 요구 사항과 구현 내용
<img width="825" alt="image" src="https://user-images.githubusercontent.com/19660039/182014918-afadb102-e0a4-42c6-bbc1-dc4534ffeb55.png">
<img width="387" alt="image" src="https://user-images.githubusercontent.com/19660039/182014929-f4d80f2a-e9b7-423b-b795-29ae955f3d19.png">

- [ac071ec](https://github.com/prgrms-web-devcourse/Team-Books-CheckMoi-FE/pull/20/commits/ac071ecb88f4e52eca7e96154933867d25e22a96) : 리나님 컴퓨터에선 라이브러리 오류가 발생하여 hast 라이브러리 설치하였습니다.
- [06ab934](https://github.com/prgrms-web-devcourse/Team-Books-CheckMoi-FE/pull/20/commits/06ab9349aeb94c9d4926fe219a0da9aba7367fe7) : next.config.js 수정을 통하여 이미지 버그 해결하였습니다.


# 요구 사항
- [x] 책 상세페이지에서 사용되는 스터디 카드 컴포넌트 구현
- [x] 스터디에 대한 간단한 정보를 게시 (자세한 정보는 스터디 모집 페이지에서 게시)
- [x] 화면 크기에 따른 카드 크기 변경
- [x] 텍스트 ellipsis 적용



# ✅ PR 포인트 & 궁금한 점

- 추후 컴포넌트 클릭할 경우 패당 스터디 모집 페이지로 이동하도록 라우팅 이벤트 추가 필요


close #8 