### PR TITLE
feat: 검색 페이지 추가. 책 검색 api, 책 클릭 이동 추가

### DIFF
--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -10,7 +10,7 @@ import { LoginButton } from "./LoginButton";
 
 // TODO 사용자 정보 불러오기
 
-const FAKE_URL = "/layoutTest";
+const FAKE_URL = "/search";
 const FAKE_QUERY_SIZE = 6;
 
 export const Topbar = () => {
@@ -50,7 +50,7 @@ export const Topbar = () => {
     }
 
     router.push({
-      pathname: `/layoutTest`,
+      pathname: FAKE_URL,
       query: { word },
     });
   };

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -1,0 +1,53 @@
+import { Box } from "@mui/system";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { getNaverBooks, registerBook } from "../../apis";
+import { BookCard } from "../../components";
+import { BookType } from "../../types/bookType";
+
+const SearchPage = () => {
+  const router = useRouter();
+  const { word } = router.query;
+
+  const [bookList, setBookList] = useState<BookType[] | null>(null);
+
+  useEffect(() => {
+    if (word)
+      getNaverBooks(word as string).then((response) => {
+        console.log(response);
+        setBookList(response.items);
+      });
+  }, [word]);
+
+  return bookList ? (
+    <Box
+      sx={{
+        display: "flex",
+        gap: "1rem",
+        flexWrap: "wrap",
+      }}
+    >
+      {bookList.map((book) => (
+        <BookCard
+          key={book.isbn}
+          src={book.image}
+          title={book.title}
+          size={10}
+          onClick={() => {
+            registerBook(
+              book,
+              process.env.NEXT_PUBLIC_FAKE_TOKEN as string
+            ).then((response) => {
+              console.log(response);
+              router.push(`/book/${response}`);
+            });
+          }}
+        />
+      ))}
+    </Box>
+  ) : (
+    "로딩 중"
+  );
+};
+
+export default SearchPage;


### PR DESCRIPTION
.env.local에
NEXT_PUBLIC_FAKE_TOKEN = "7번 로그인해서 받은 FAKE 토큰"
을 추가해주세요

- 검색 한 내용의 책을 네이버 API로 검색 후 렌더링
- 렌더링된 책을 클릭하면 가짜 토큰을 포함해서 책 등록 요청 이후 받은 ID의 책 상세 페이지로 이동

close issue #44 