### PR TITLE
feat: BookDetail 스터디개설하기 버튼 위치 변경

### DIFF
--- a/components/BookDetailCard/BookDetailCard.tsx
+++ b/components/BookDetailCard/BookDetailCard.tsx
@@ -25,9 +25,14 @@ export const BookDetail = ({
 }: BookDetailProps) => {
   return (
     <S.BookDetailCard>
-      <S.ImageWrapper>
-        <Image width={size} height={size * 1.5} src={src} />
-      </S.ImageWrapper>
+      <S.ImageContainer>
+        <S.ImageWrapper>
+          <Image width={size} height={size * 1.5} src={src} />
+        </S.ImageWrapper>
+        <S.StyledButton variant="contained" color="primary">
+          스터디 개설하기
+        </S.StyledButton>
+      </S.ImageContainer>
       <S.BookInfoConatiner>
         <S.ResponsiveText fontSize={1.3}>{title}</S.ResponsiveText>
         <S.ResponsiveText>
@@ -41,9 +46,6 @@ export const BookDetail = ({
           {description}
         </S.BookDescription>
       </S.BookInfoConatiner>
-      <S.StyledButton variant="contained" color="primary">
-        스터디 개설하기
-      </S.StyledButton>
     </S.BookDetailCard>
   );
 };

--- a/components/BookDetailCard/style.tsx
+++ b/components/BookDetailCard/style.tsx
@@ -16,6 +16,12 @@ export const BookDetailCard = styled(Card)`
   }
 `;
 
+export const ImageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+`;
+
 export const ImageWrapper = styled.div`
   flex-shrink: 0;
   & span {
@@ -23,6 +29,7 @@ export const ImageWrapper = styled.div`
     padding: 0;
     display: inline !important;
   }
+
   @media (max-width: 600px) {
     box-shadow: -12px 17px 16px 3px rgba(0, 0, 0, 0.1),
       13px 0px 15px 4px rgba(0, 0, 0, 0.1);
@@ -64,10 +71,11 @@ export const StyledButton = styled(Button)`
   min-width: 9rem;
   max-height: 2rem;
   position: absolute;
-  right: 2rem;
-  top: 1rem;
 
-  @media (max-width: 600px) {
+  position: relative;
+  margin-top: 1rem;
+
+  @media (max-width: 512px) {
     position: relative;
     margin-bottom: 1rem;
   }


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
![Kapture 2022-08-05 at 15 03 19](https://user-images.githubusercontent.com/10705018/183011959-8cdd57da-241b-4438-ac78-05d38d55401e.gif)

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
기존 bookDetail 컴포넌트가 책 제목이 길어질시 스터디 개설하기 버튼에 가려지는 문제 발생
-> 해서 책 아래에 버튼위치 이동

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

디자인 괜찮나요?

### 🚀 연관된 이슈
close #49