### PR TITLE
#70/feat/snackbar

### DIFF
--- a/contexts/UserContextProvider.tsx
+++ b/contexts/UserContextProvider.tsx
@@ -1,7 +1,6 @@
 import { createContext, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import type { User } from "../types/userType";
-import { logout } from "../apis/user";
 
 interface UserActionType {
   login: (inputUser: User) => void;
@@ -28,10 +27,7 @@ const UserContextProvider = ({
       login(inputUser: User) {
         setUser(inputUser);
       },
-      async logout() {
-        const token = document.cookie.split("token=");
-        await logout(token[1]);
-        document.cookie = "token=; max-age=0;";
+      logout() {
         setUser(null);
       },
     }),

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { FormEvent } from "react";
 import { Toolbar } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
@@ -52,6 +52,10 @@ export const Topbar = () => {
       query: { word },
     });
   };
+
+  useEffect(() => {
+    if (user) renderSnackbar("로그인에 성공했습니다");
+  }, [user]);
 
   return (
     <S.StyledAppbar position="fixed">

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -8,6 +8,7 @@ import * as S from "./style";
 import { UserProfile } from "./UserProfile";
 import { LoginButton } from "./LoginButton";
 import { useUserContext } from "../../hooks/useUserContext";
+import { useOurSnackbar } from "../../hooks/useOurSnackbar";
 
 // TODO 사용자 정보 불러오기
 
@@ -34,14 +35,15 @@ export const Topbar = () => {
         inputRef.current.value = decodeURIComponent(urlWord);
     } else if (inputRef.current) inputRef.current.value = "";
 
+  const { renderSnackbar } = useOurSnackbar();
+
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const target = e.target as Element;
     const word = target.querySelector("input")?.value.trim();
 
     if (!word) {
-      // TODO alert 통일해서 추가하기
-      alert("검색 값을 입력해주세요");
+      renderSnackbar("찾으려는 책을 입력해주세요", "warning");
       return;
     }
 

--- a/features/Topbar/UserProfile/LogoutModal.tsx
+++ b/features/Topbar/UserProfile/LogoutModal.tsx
@@ -1,4 +1,6 @@
 import { Box, Button, Modal, Typography } from "@mui/material";
+import { logout as logoutApi } from "../../../apis/user";
+import { useOurSnackbar } from "../../../hooks/useOurSnackbar";
 import { useUserActionContext } from "../../../hooks/useUserContext";
 import * as S from "./style";
 
@@ -9,11 +11,18 @@ interface LogoutModalProps {
 
 const LogoutModal = ({ open, handleModalClose }: LogoutModalProps) => {
   const { logout } = useUserActionContext();
+  const { renderSnackbar } = useOurSnackbar();
 
-  const handleLogoutClick = () => {
-    logout();
-    // TODO alert 추가
-    alert("로그아웃에 성공했습니다");
+  const handleLogoutClick = async () => {
+    try {
+      const token = document.cookie.split("token=");
+      await logoutApi(token[1]);
+      document.cookie = "token=; max-age=0;";
+      logout();
+      renderSnackbar("로그아웃에 성공했습니다");
+    } catch (error) {
+      renderSnackbar("로그아웃에 실패했습니다", "warning");
+    }
   };
 
   const style = {

--- a/hooks/useOurSnackbar/index.ts
+++ b/hooks/useOurSnackbar/index.ts
@@ -1,0 +1,1 @@
+export { useOurSnackbar } from "./useOurSnackbar";

--- a/hooks/useOurSnackbar/style.ts
+++ b/hooks/useOurSnackbar/style.ts
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+import { Button } from "@mui/material";
+
+export const StyledButton = styled(Button)`
+  color: white;
+`;

--- a/hooks/useOurSnackbar/useOurSnackbar.tsx
+++ b/hooks/useOurSnackbar/useOurSnackbar.tsx
@@ -1,0 +1,31 @@
+import { useCallback } from "react";
+import { useSnackbar } from "notistack";
+import type { VariantType } from "notistack";
+import * as S from "./style";
+
+type RenderSnackbarType = (message: string, variant?: VariantType) => void;
+
+export const useOurSnackbar = () => {
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+
+  const renderSnackbar = useCallback<RenderSnackbarType>(
+    (message, variant = "success") => {
+      enqueueSnackbar(message, {
+        variant,
+        autoHideDuration: 2000,
+        anchorOrigin: {
+          horizontal: "right",
+          vertical: "bottom",
+        },
+        action: (snackbarId) => (
+          <S.StyledButton onClick={() => closeSnackbar(snackbarId)}>
+            닫기
+          </S.StyledButton>
+        ),
+      });
+    },
+    []
+  );
+
+  return { renderSnackbar };
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@mui/material": "^5.9.2",
     "hast": "^1.0.0",
     "next": "12.2.3",
+    "notistack": "^2.0.5",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import { useRef } from "react";
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
 import { SnackbarProvider } from "notistack";
@@ -14,10 +13,8 @@ interface MyAppProps extends AppProps {
 }
 
 const MyApp = ({ Component, pageProps, user }: MyAppProps) => {
-  const snackbarRef = useRef<SnackbarProvider>(null);
-
   return (
-    <SnackbarProvider maxSnack={3} ref={snackbarRef}>
+    <SnackbarProvider maxSnack={3}>
       <UserContextProvider initialUser={user}>
         <Topbar />
         <S.ContentContainer>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable react/jsx-props-no-spreading */
+import { useRef } from "react";
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
+import { SnackbarProvider } from "notistack";
 import { Topbar } from "../features/Topbar";
 import * as S from "../styles/LayoutStyle";
 import UserContextProvider from "../contexts/UserContextProvider";
@@ -12,13 +14,17 @@ interface MyAppProps extends AppProps {
 }
 
 const MyApp = ({ Component, pageProps, user }: MyAppProps) => {
+  const snackbarRef = useRef<SnackbarProvider>(null);
+
   return (
-    <UserContextProvider initialUser={user}>
-      <Topbar />
-      <S.ContentContainer>
-        <Component {...pageProps} />
-      </S.ContentContainer>
-    </UserContextProvider>
+    <SnackbarProvider maxSnack={3} ref={snackbarRef}>
+      <UserContextProvider initialUser={user}>
+        <Topbar />
+        <S.ContentContainer>
+          <Component {...pageProps} />
+        </S.ContentContainer>
+      </UserContextProvider>
+    </SnackbarProvider>
   );
 };
 

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -4,12 +4,14 @@ import { CircularProgress as CircularLoading } from "@mui/material";
 import { StyledBackDrop } from "../../styles/LoginPageStyle";
 import { getMyInfo } from "../../apis/user";
 import { useUserActionContext } from "../../hooks/useUserContext";
+import { useOurSnackbar } from "../../hooks/useOurSnackbar";
 
 const LoginPage = () => {
   const { login } = useUserActionContext();
   const router = useRouter();
   const { token } = router.query;
   const [isLoginDone, setIsLoginDone] = useState<boolean | null>(null);
+  const { renderSnackbar } = useOurSnackbar();
 
   useEffect(() => {
     if (token) {
@@ -33,8 +35,7 @@ const LoginPage = () => {
     }
 
     router.push("/");
-    // TODO alert 추가
-    alert("로그인에 실패했습니다");
+    renderSnackbar("로그인에 실패했습니다", "warning");
   }, [isLoginDone]);
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4403,7 +4403,7 @@ clsx@1.1.0:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
   integrity sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==
 
-clsx@^1.0.4, clsx@^1.2.1:
+clsx@^1.0.4, clsx@^1.1.0, clsx@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
@@ -6510,7 +6510,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -8121,6 +8121,14 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
+
+notistack@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-2.0.5.tgz#8eb53720453f6e02182cd0e6784ced630a7bb7e6"
+  integrity sha512-Ig2T1Muqkc1PaSQcEDrK7diKv6cBxw02Iq6uv074ySfgq524TV5lK41diAb6OSsaiWfp3aRt+T3+0MF8m2EcJQ==
+  dependencies:
+    clsx "^1.1.0"
+    hoist-non-react-statics "^3.3.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

**snackbar 개발했습니다**

사용자의 액션에 대해서 특히 네트워크 요청에 대해 성공 / 실패 등 결과를 알려주는것으로 개발시에는 alert를 쓰고 있었습니다

[Mui Alert](https://mui.com/material-ui/react-alert)와 [Mui Snackbar](https://mui.com/material-ui/react-snackbar)중에서 한번 논의한바로는 snackbar쪽으로 의견이 모아진것으로 기억합니다

그래서 [Mui Snackbar](https://mui.com/material-ui/react-snackbar) 맨 아래 notistack 부분과 [notistack docs](https://notistack.com/getting-started)를 참고하여 useOurSnackbar 훅을 만들었습니다

월요일에 타입관련 대규모 병합 충돌을 해결해야 하니까 snackbar는 우선 제가 쓰는곳에만 적용했습니다
로그인 - 빈 값 검색 - 로그아웃에 따른 snackbar 결과 캡처입니다

로그인 useEffect로 해서 2번 뜨는데 이거 strict mode 때문입니다
yarn build해서 확인하면 1번 뜹니다

![snackbar](https://user-images.githubusercontent.com/50919342/183255550-68a586e8-bfe9-467a-b063-2ca787d4054d.gif)

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

**snackbar에 공통적으로 설정한 사항**
- snackbar는 최대 3개까지 쌓입니다
- 3초 뒤에 자동으로 사라지거나 닫기 버튼을 누르면 바로 없어집니다
- 오른쪽 아래로 설정해놨습니다

**useOurSnackbar 사용법**
- useOurSnackbar()가 반환하는 renderSnackbar 함수를 사용합니다
- renderSnackbar는 인자로 메시지, 타입을 받습니다
- 타입은 기본 success 초록색이기 때문에 성공은 지정하지 않아도 됩니다
- 이외에 warning, error, info 등이 있습니다

```
import { useOurSnackbar } from "..경로/hooks/useOurSnackbar";

const Component = () => {
  const { renderSnackbar } = useOurSnackbar();

  renderSnackbar('ㅇㅇ요청에 성공했습니다');
  renderSnackbar('ㅇㅇ요청에 실패했습니다', 'warning');

  return (
    <>
    </>
  )
}
```

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

- 왼쪽 위 / 오른쪽 위로 하고 싶었는데 Topbar랑 겹칩니다.
style을 주게되면 snackbar 하나하나에 들어가서 여러개 쌓일때 모양이 이상해요
- [notistack type](https://notistack.com/examples#variants)이 이렇게 있는데 성공 / 실패만 정해서 사용할까요?
- [notistack transition](https://notistack.com/examples#transition)에서 효과를 줄 수 있는데 추가할까요?
- 다른 분들 요청에 대한 snackbar는 충돌이 심할까봐 안건드렸습니다

### 🚀 연관된 이슈

close issue #70 