### PR TITLE
#73/feat/study detail page tab

### DIFF
--- a/commons/dummyPost.ts
+++ b/commons/dummyPost.ts
@@ -1,0 +1,154 @@
+import type { PostType } from "../types/postType";
+
+export const DummyPost: PostType[] = [
+  {
+    id: 1,
+    title: "Dummy Post1",
+    content:
+      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
+    createdAt: "2020/08/07",
+    comments: 10,
+    size: 20,
+    user: {
+      userId: "DummyID",
+      name: "Dummy",
+      email: "DummyEmail",
+      img: "https://picsum.photos/200",
+    },
+  },
+  {
+    id: 2,
+    title: "Dummy Post2",
+    content:
+      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
+    createdAt: "2020/08/07",
+    comments: 10,
+    size: 20,
+    user: {
+      userId: "DummyID",
+      name: "Dummy",
+      email: "DummyEmail",
+      img: "https://picsum.photos/200",
+    },
+  },
+  {
+    id: 3,
+    title: "Dummy Post3",
+    content:
+      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
+    createdAt: "2020/08/07",
+    comments: 10,
+    size: 20,
+    user: {
+      userId: "DummyID",
+      name: "Dummy",
+      email: "DummyEmail",
+      img: "https://picsum.photos/200",
+    },
+  },
+  {
+    id: 4,
+    title: "Dummy Post4",
+    content:
+      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
+    createdAt: "2020/08/07",
+    comments: 10,
+    size: 20,
+    user: {
+      userId: "DummyID",
+      name: "Dummy",
+      email: "DummyEmail",
+      img: "https://picsum.photos/200",
+    },
+  },
+  {
+    id: 5,
+    title: "Dummy Post5",
+    content:
+      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
+    createdAt: "2020/08/07",
+    comments: 10,
+    size: 20,
+    user: {
+      userId: "DummyID",
+      name: "Dummy",
+      email: "DummyEmail",
+      img: "https://picsum.photos/200",
+    },
+  },
+  {
+    id: 6,
+    title: "Dummy Post6",
+    content:
+      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
+    createdAt: "2020/08/07",
+    comments: 10,
+    size: 20,
+    user: {
+      userId: "DummyID",
+      name: "Dummy",
+      email: "DummyEmail",
+      img: "https://picsum.photos/200",
+    },
+  },
+  {
+    id: 7,
+    title: "Dummy Post7",
+    content:
+      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
+    createdAt: "2020/08/07",
+    comments: 10,
+    size: 20,
+    user: {
+      userId: "DummyID",
+      name: "Dummy",
+      email: "DummyEmail",
+      img: "https://picsum.photos/200",
+    },
+  },
+  {
+    id: 8,
+    title: "Dummy Post8",
+    content:
+      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
+    createdAt: "2020/08/07",
+    comments: 10,
+    size: 20,
+    user: {
+      userId: "DummyID",
+      name: "Dummy",
+      email: "DummyEmail",
+      img: "https://picsum.photos/200",
+    },
+  },
+  {
+    id: 9,
+    title: "Dummy Post9",
+    content:
+      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
+    createdAt: "2020/08/07",
+    comments: 10,
+    size: 20,
+    user: {
+      userId: "DummyID",
+      name: "Dummy",
+      email: "DummyEmail",
+      img: "https://picsum.photos/200",
+    },
+  },
+  {
+    id: 10,
+    title: "Dummy Post10",
+    content:
+      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
+    createdAt: "2020/08/07",
+    comments: 10,
+    size: 20,
+    user: {
+      userId: "DummyID",
+      name: "Dummy",
+      email: "DummyEmail",
+      img: "https://picsum.photos/200",
+    },
+  },
+];

--- a/commons/dummyPost.ts
+++ b/commons/dummyPost.ts
@@ -2,7 +2,7 @@ import type { PostType } from "../types/postType";
 
 export const DummyPost: PostType[] = [
   {
-    id: 1,
+    id: "1",
     title: "Dummy Post1",
     content:
       "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
@@ -17,7 +17,7 @@ export const DummyPost: PostType[] = [
     },
   },
   {
-    id: 2,
+    id: "2",
     title: "Dummy Post2",
     content:
       "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
@@ -32,7 +32,7 @@ export const DummyPost: PostType[] = [
     },
   },
   {
-    id: 3,
+    id: "3",
     title: "Dummy Post3",
     content:
       "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
@@ -47,7 +47,7 @@ export const DummyPost: PostType[] = [
     },
   },
   {
-    id: 4,
+    id: "4",
     title: "Dummy Post4",
     content:
       "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
@@ -62,7 +62,7 @@ export const DummyPost: PostType[] = [
     },
   },
   {
-    id: 5,
+    id: "5",
     title: "Dummy Post5",
     content:
       "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
@@ -77,7 +77,7 @@ export const DummyPost: PostType[] = [
     },
   },
   {
-    id: 6,
+    id: "6",
     title: "Dummy Post6",
     content:
       "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
@@ -92,7 +92,7 @@ export const DummyPost: PostType[] = [
     },
   },
   {
-    id: 7,
+    id: "7",
     title: "Dummy Post7",
     content:
       "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
@@ -107,7 +107,7 @@ export const DummyPost: PostType[] = [
     },
   },
   {
-    id: 8,
+    id: "8",
     title: "Dummy Post8",
     content:
       "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
@@ -122,7 +122,7 @@ export const DummyPost: PostType[] = [
     },
   },
   {
-    id: 9,
+    id: "9",
     title: "Dummy Post9",
     content:
       "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",
@@ -137,7 +137,7 @@ export const DummyPost: PostType[] = [
     },
   },
   {
-    id: 10,
+    id: "10",
     title: "Dummy Post10",
     content:
       "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia, nemo harum sapiente molestias non iste facilis rerum numquam, ducimus unde ut. Reprehenderit in expedita nostrum aut porro libero, ab debitis.",

--- a/components/PostCard/PostCard.stories.tsx
+++ b/components/PostCard/PostCard.stories.tsx
@@ -12,19 +12,22 @@ const Template: ComponentStory<typeof PostCard> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  title: "This is Title!!~",
-  content:
-    "Lorem ipsum dolor sit amet consectetur adipisicing elit. Molestiae voluptatem, error optio atque sed eaque possimus nihil, delectus incidunt minus porro iusto laboriosam illum est rem enim dolore suscipit rerum?",
-  createdAt: "2022/08/05",
-  comments: 10,
-  size: 20,
-  user: {
-    userId: "asdasdsa@naver.com",
-    name: "김민기",
-    email: "asdasdsa@naver.com",
-    img: "https://picsum.photos/200",
-  },
-  onClick: () => {
-    console.log("Move PostDetail Page");
+  post: {
+    id: "1",
+    title: "This is Title!!~",
+    content:
+      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Molestiae voluptatem, error optio atque sed eaque possimus nihil, delectus incidunt minus porro iusto laboriosam illum est rem enim dolore suscipit rerum?",
+    createdAt: "2022/08/05",
+    comments: 10,
+    size: 20,
+    user: {
+      userId: "asdasdsa@naver.com",
+      name: "김민기",
+      email: "asdasdsa@naver.com",
+      img: "https://picsum.photos/200",
+    },
+    onClick: () => {
+      console.log("Move PostDetail Page");
+    },
   },
 };

--- a/components/PostCard/PostCard.tsx
+++ b/components/PostCard/PostCard.tsx
@@ -1,32 +1,26 @@
-import type { MouseEventHandler } from "react";
 import { Avatar, Badge, Divider } from "@mui/material";
 import ChatIcon from "@mui/icons-material/Chat";
 import type { PostType } from "../../types/postType";
 import * as S from "./style";
-import { User } from "../../types/userType";
 
-export const PostCard = ({
-  title,
-  content,
-  createdAt,
-  comments,
-  size,
-  user,
-  onClick,
-}: PostType) => {
-  const [year, month, day] = createdAt.split("/");
+interface PostCardProps {
+  post: PostType;
+}
+
+export const PostCard = ({ post }: PostCardProps) => {
+  const [year, month, day] = post.createdAt.split("/");
   return (
-    <S.PostCard size={size} onClick={onClick}>
-      <S.PostTitle>{title}</S.PostTitle>
-      <S.PostContent>{content}</S.PostContent>
+    <S.PostCard size={post.size} onClick={post.onClick}>
+      <S.PostTitle>{post.title}</S.PostTitle>
+      <S.PostContent>{post.content}</S.PostContent>
       <S.PostCreatedAt>{`${year}년 ${month}월 ${day}일`}</S.PostCreatedAt>
       <Divider light />
       <S.PostBottomContainer>
         <S.PostUserWarpper>
-          <Avatar src={user.img} />
-          {user.userId}
+          <Avatar src={post.user.img} />
+          {post.user.userId}
         </S.PostUserWarpper>
-        <Badge badgeContent={comments} color="primary">
+        <Badge badgeContent={post.comments} color="primary">
           <ChatIcon color="action" />
         </Badge>
       </S.PostBottomContainer>

--- a/components/PostCard/PostCard.tsx
+++ b/components/PostCard/PostCard.tsx
@@ -1,18 +1,9 @@
 import type { MouseEventHandler } from "react";
 import { Avatar, Badge, Divider } from "@mui/material";
 import ChatIcon from "@mui/icons-material/Chat";
+import type { PostType } from "../../types/postType";
 import * as S from "./style";
 import { User } from "../../types/userType";
-
-interface PostProps {
-  title: string;
-  content: string;
-  createdAt: string;
-  comments: number;
-  size: number;
-  user: User;
-  onClick?: MouseEventHandler<HTMLElement>;
-}
 
 export const PostCard = ({
   title,
@@ -22,7 +13,7 @@ export const PostCard = ({
   size,
   user,
   onClick,
-}: PostProps) => {
+}: PostType) => {
   const [year, month, day] = createdAt.split("/");
   return (
     <S.PostCard size={size} onClick={onClick}>

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -8,7 +8,7 @@ import { StudyDetailCard } from "../../components/StudyDetailCard";
 import { getStudyDetailInfo } from "../../apis/study";
 import { PostCard } from "../../components/PostCard";
 import { DummyPost } from "../../commons/dummyPost";
-import * as S from "../../styles/StudyDetailStyle";
+import * as S from "../../styles/StudyDetailPageStyle";
 
 interface ServerSidePropType {
   studyData: StudyDetailType;

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -20,83 +20,50 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
   const { id: studyID, value: tabValue } = router.query;
   const currentTab = tabValue ? parseInt(tabValue as string, 10) : 0;
 
-  const [value, setValue] = useState(currentTab);
+  const [tabNumber, setTabValue] = useState(currentTab);
   const { study, members } = studyData;
   const handleTabChange = (e: React.SyntheticEvent, newValue: number) => {
-    setValue(newValue);
+    setTabValue(newValue);
   };
 
   // TODO 게시글 클릭 시 value 값을 갖고 게시글 상세 페이지로 이동 확인
   // TODO API 연동 확인
   const handlePostClick = (id: number) => {
-    router.push(`/boardDetail/${id}`, { query: { value } });
+    router.push(`/boardDetail/${id}`, { query: { tabNumber } });
   };
   return (
     <>
       <StudyDetailCard study={study} members={members} />
 
-      <Tabs value={value} onChange={handleTabChange}>
+      <Tabs value={tabNumber} onChange={handleTabChange}>
         <Tab label="공지" />
         <Tab label="자유" />
         <Tab label="관리자" disabled />
       </Tabs>
       <S.StyledTab>
-        <TabPanel value={value} index={0}>
+        <TabPanel value={tabNumber} index={0}>
           <S.StyledUl>
             {DummyPost.map((post) => (
               <S.StyledList key={post.id}>
-                <PostCard
-                  id={post.id}
-                  title={post.title}
-                  content={post.content}
-                  comments={post.comments}
-                  createdAt={post.createdAt}
-                  size={post.size}
-                  user={post.user}
-                  onClick={() => {
-                    handlePostClick(post.id);
-                  }}
-                />
+                <PostCard post={post} />
               </S.StyledList>
             ))}
           </S.StyledUl>
         </TabPanel>
-        <TabPanel value={value} index={1}>
+        <TabPanel value={tabNumber} index={1}>
           <S.StyledUl>
             {DummyPost.map((post) => (
               <S.StyledList key={post.id}>
-                <PostCard
-                  id={post.id}
-                  title={post.title}
-                  content={post.content}
-                  comments={post.comments}
-                  createdAt={post.createdAt}
-                  size={post.size}
-                  user={post.user}
-                  onClick={() => {
-                    handlePostClick(post.id);
-                  }}
-                />
+                <PostCard post={post} />
               </S.StyledList>
             ))}
           </S.StyledUl>
         </TabPanel>
-        <TabPanel value={value} index={2}>
+        <TabPanel value={tabNumber} index={2}>
           <S.StyledUl>
             {DummyPost.map((post) => (
               <S.StyledList key={post.id}>
-                <PostCard
-                  id={post.id}
-                  title={post.title}
-                  content={post.content}
-                  comments={post.comments}
-                  createdAt={post.createdAt}
-                  size={post.size}
-                  user={post.user}
-                  onClick={() => {
-                    handlePostClick(post.id);
-                  }}
-                />
+                <PostCard post={post} />
               </S.StyledList>
             ))}
           </S.StyledUl>

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -8,6 +8,7 @@ import { StudyDetailCard } from "../../components/StudyDetailCard";
 import { getStudyDetailInfo } from "../../apis/study";
 import { PostCard } from "../../components/PostCard";
 import { DummyPost } from "../../commons/dummyPost";
+import * as S from "../../styles/StudyDetailStyle";
 
 interface ServerSidePropType {
   studyData: StudyDetailType;
@@ -42,9 +43,9 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
       </Tabs>
 
       <TabPanel value={value} index={0}>
-        <ul>
+        <S.StyledUl>
           {DummyPost.map((post) => (
-            <li key={post.id}>
+            <S.StyledList key={post.id}>
               <PostCard
                 id={post.id}
                 title={post.title}
@@ -57,49 +58,49 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
                   handlePostClick(post.id);
                 }}
               />
-            </li>
+            </S.StyledList>
           ))}
-        </ul>
-        {/* <PostCard
-          id={1}
-          title={DummyPost.title}
-          content={DummyPost.content}
-          createdAt={DummyPost.createdAt}
-          comments={DummyPost.comments}
-          size={DummyPost.size}
-          user={DummyPost.user}
-          onClick={() => {
-            handlePostClick();
-          }}
-        /> */}
+        </S.StyledUl>
       </TabPanel>
       <TabPanel value={value} index={1}>
-        {/* { <PostCard
-          id={2}
-          title={DummyPost.title}
-          content={DummyPost.content}
-          createdAt={DummyPost.createdAt}
-          comments={DummyPost.comments}
-          size={DummyPost.size}
-          user={DummyPost.user}
-          onClick={() => {
-            handlePostClick();
-          }} 
-        /> */}
+        <S.StyledUl>
+          {DummyPost.map((post) => (
+            <S.StyledList key={post.id}>
+              <PostCard
+                id={post.id}
+                title={post.title}
+                content={post.content}
+                comments={post.comments}
+                createdAt={post.createdAt}
+                size={post.size}
+                user={post.user}
+                onClick={() => {
+                  handlePostClick(post.id);
+                }}
+              />
+            </S.StyledList>
+          ))}
+        </S.StyledUl>
       </TabPanel>
       <TabPanel value={value} index={2}>
-        {/* <PostCard
-          id={3}
-          title={DummyPost.title}
-          content={DummyPost.content}
-          createdAt={DummyPost.createdAt}
-          comments={DummyPost.comments}
-          size={DummyPost.size}
-          user={DummyPost.user}
-          onClick={() => {
-            handlePostClick();
-          }}
-        /> */}
+        <S.StyledUl>
+          {DummyPost.map((post) => (
+            <S.StyledList key={post.id}>
+              <PostCard
+                id={post.id}
+                title={post.title}
+                content={post.content}
+                comments={post.comments}
+                createdAt={post.createdAt}
+                size={post.size}
+                user={post.user}
+                onClick={() => {
+                  handlePostClick(post.id);
+                }}
+              />
+            </S.StyledList>
+          ))}
+        </S.StyledUl>
       </TabPanel>
     </>
   );

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -26,11 +26,10 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
     setValue(newValue);
   };
 
-  // TODO PostCard를 몇 개씩 보여줄지 웹에서 가로 3개? 모바일에서 2개? 스타일 필요.
-  // TODO 게시글 클릭 시 value 값을 갖고 게시글 상세 페이지로 이동
-  // TODO 실제 API로 전달 받아서 map 실행 해야 함. map에서 key를 어떤 것으로 사용할지
+  // TODO 게시글 클릭 시 value 값을 갖고 게시글 상세 페이지로 이동 확인
+  // TODO API 연동 확인
   const handlePostClick = (id: number) => {
-    router.push(`/postDetail/${id}`, { query: { value } });
+    router.push(`/boardDetail/${id}`, { query: { value } });
   };
   return (
     <>
@@ -41,67 +40,68 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
         <Tab label="자유" />
         <Tab label="관리자" disabled />
       </Tabs>
-
-      <TabPanel value={value} index={0}>
-        <S.StyledUl>
-          {DummyPost.map((post) => (
-            <S.StyledList key={post.id}>
-              <PostCard
-                id={post.id}
-                title={post.title}
-                content={post.content}
-                comments={post.comments}
-                createdAt={post.createdAt}
-                size={post.size}
-                user={post.user}
-                onClick={() => {
-                  handlePostClick(post.id);
-                }}
-              />
-            </S.StyledList>
-          ))}
-        </S.StyledUl>
-      </TabPanel>
-      <TabPanel value={value} index={1}>
-        <S.StyledUl>
-          {DummyPost.map((post) => (
-            <S.StyledList key={post.id}>
-              <PostCard
-                id={post.id}
-                title={post.title}
-                content={post.content}
-                comments={post.comments}
-                createdAt={post.createdAt}
-                size={post.size}
-                user={post.user}
-                onClick={() => {
-                  handlePostClick(post.id);
-                }}
-              />
-            </S.StyledList>
-          ))}
-        </S.StyledUl>
-      </TabPanel>
-      <TabPanel value={value} index={2}>
-        <S.StyledUl>
-          {DummyPost.map((post) => (
-            <S.StyledList key={post.id}>
-              <PostCard
-                id={post.id}
-                title={post.title}
-                content={post.content}
-                comments={post.comments}
-                createdAt={post.createdAt}
-                size={post.size}
-                user={post.user}
-                onClick={() => {
-                  handlePostClick(post.id);
-                }}
-              />
-            </S.StyledList>
-          ))}
-        </S.StyledUl>
-      </TabPanel>
+      <S.StyledTab>
+        <TabPanel value={value} index={0}>
+          <S.StyledUl>
+            {DummyPost.map((post) => (
+              <S.StyledList key={post.id}>
+                <PostCard
+                  id={post.id}
+                  title={post.title}
+                  content={post.content}
+                  comments={post.comments}
+                  createdAt={post.createdAt}
+                  size={post.size}
+                  user={post.user}
+                  onClick={() => {
+                    handlePostClick(post.id);
+                  }}
+                />
+              </S.StyledList>
+            ))}
+          </S.StyledUl>
+        </TabPanel>
+        <TabPanel value={value} index={1}>
+          <S.StyledUl>
+            {DummyPost.map((post) => (
+              <S.StyledList key={post.id}>
+                <PostCard
+                  id={post.id}
+                  title={post.title}
+                  content={post.content}
+                  comments={post.comments}
+                  createdAt={post.createdAt}
+                  size={post.size}
+                  user={post.user}
+                  onClick={() => {
+                    handlePostClick(post.id);
+                  }}
+                />
+              </S.StyledList>
+            ))}
+          </S.StyledUl>
+        </TabPanel>
+        <TabPanel value={value} index={2}>
+          <S.StyledUl>
+            {DummyPost.map((post) => (
+              <S.StyledList key={post.id}>
+                <PostCard
+                  id={post.id}
+                  title={post.title}
+                  content={post.content}
+                  comments={post.comments}
+                  createdAt={post.createdAt}
+                  size={post.size}
+                  user={post.user}
+                  onClick={() => {
+                    handlePostClick(post.id);
+                  }}
+                />
+              </S.StyledList>
+            ))}
+          </S.StyledUl>
+        </TabPanel>
+      </S.StyledTab>
     </>
   );
 };

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -1,63 +1,36 @@
 import React, { useState } from "react";
 import { Tabs, Tab } from "@mui/material";
 import type { GetServerSideProps } from "next/types";
+import { useRouter } from "next/router";
 import type { StudyDetailType } from "../../types/studyType";
 import { TabPanel } from "../../components";
 import { StudyDetailCard } from "../../components/StudyDetailCard";
 import { getStudyDetailInfo } from "../../apis/study";
-
-const DummyBoard = () => {
-  return (
-    <div>
-      <h1>Notice</h1>
-      <p>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Labore
-        aspernatur voluptas doloribus quae perferendis asperiores quos eos, sint
-        molestiae cum veniam maxime quisquam voluptate cupiditate facere atque
-        nam tenetur necessitatibus?
-      </p>
-    </div>
-  );
-};
-
-const DummyArticle = () => {
-  return (
-    <div>
-      <h1>Article</h1>
-      <p>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Sint id vel
-        numquam assumenda magni amet asperiores quo voluptas tempore perferendis
-        esse, officiis architecto vitae rem voluptate rerum consectetur in
-        necessitatibus.
-      </p>
-    </div>
-  );
-};
-
-const DummyFreeTalk = () => {
-  return (
-    <div>
-      <h1>FreeTalk</h1>
-      <p>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Eum molestias
-        amet porro? Nemo dicta amet libero dolores. Ullam magnam, iste
-        doloremque nihil sint ipsum, totam porro provident molestiae vero ad.
-      </p>
-    </div>
-  );
-};
+import { PostCard } from "../../components/PostCard";
+import { DummyPost } from "../../commons/dummyPost";
 
 interface ServerSidePropType {
   studyData: StudyDetailType;
 }
 
 const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
-  const [value, setValue] = useState(0);
+  // TODO router에 value query가 있으면 setValue로 실행.
+  const router = useRouter();
+  const { id: studyID, value: tabValue } = router.query;
+  const currentTab = tabValue ? parseInt(tabValue as string, 10) : 0;
+
+  const [value, setValue] = useState(currentTab);
   const { study, members } = studyData;
   const handleTabChange = (e: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
   };
 
+  // TODO PostCard를 몇 개씩 보여줄지 웹에서 가로 3개? 모바일에서 2개? 스타일 필요.
+  // TODO 게시글 클릭 시 value 값을 갖고 게시글 상세 페이지로 이동
+  // TODO 실제 API로 전달 받아서 map 실행 해야 함. map에서 key를 어떤 것으로 사용할지
+  const handlePostClick = (id: number) => {
+    router.push(`/postDetail/${id}`, { query: { value } });
+  };
   return (
     <>
       <StudyDetailCard study={study} members={members} />
@@ -69,13 +42,64 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
       </Tabs>
 
       <TabPanel value={value} index={0}>
-        <DummyBoard />
+        <ul>
+          {DummyPost.map((post) => (
+            <li key={post.id}>
+              <PostCard
+                id={post.id}
+                title={post.title}
+                content={post.content}
+                comments={post.comments}
+                createdAt={post.createdAt}
+                size={post.size}
+                user={post.user}
+                onClick={() => {
+                  handlePostClick(post.id);
+                }}
+              />
+            </li>
+          ))}
+        </ul>
+        {/* <PostCard
+          id={1}
+          title={DummyPost.title}
+          content={DummyPost.content}
+          createdAt={DummyPost.createdAt}
+          comments={DummyPost.comments}
+          size={DummyPost.size}
+          user={DummyPost.user}
+          onClick={() => {
+            handlePostClick();
+          }}
+        /> */}
       </TabPanel>
       <TabPanel value={value} index={1}>
-        <DummyArticle />
+        {/* { <PostCard
+          id={2}
+          title={DummyPost.title}
+          content={DummyPost.content}
+          createdAt={DummyPost.createdAt}
+          comments={DummyPost.comments}
+          size={DummyPost.size}
+          user={DummyPost.user}
+          onClick={() => {
+            handlePostClick();
+          }} 
+        /> */}
       </TabPanel>
       <TabPanel value={value} index={2}>
-        <DummyFreeTalk />
+        {/* <PostCard
+          id={3}
+          title={DummyPost.title}
+          content={DummyPost.content}
+          createdAt={DummyPost.createdAt}
+          comments={DummyPost.comments}
+          size={DummyPost.size}
+          user={DummyPost.user}
+          onClick={() => {
+            handlePostClick();
+          }}
+        /> */}
       </TabPanel>
     </>
   );

--- a/styles/StudyDetailPageStyle.tsx
+++ b/styles/StudyDetailPageStyle.tsx
@@ -1,7 +1,5 @@
 import styled from "@emotion/styled";
 
-export const StyledTab = styled.div``;
-
 export const StyledUl = styled("ul")`
   list-style: none;
   display: grid;

--- a/styles/StudyDetailStyle.tsx
+++ b/styles/StudyDetailStyle.tsx
@@ -1,18 +1,9 @@
 import styled from "@emotion/styled";
 
-export const MainPageWrapper = styled("div")`
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  @media (min-width: 1500px) {
-    margin: auto 10rem;
-  }
-`;
-
 export const StyledUl = styled("ul")`
   list-style: none;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
   gap: 1rem;
   align-items: start;
   -webkit-padding-start: 0px;
@@ -27,9 +18,4 @@ export const StyledList = styled("li")`
   &:hover {
     transform: scale(1.05) translateY(-10px);
   }
-`;
-
-export const StyledSpan = styled("span")`
-  font-size: 1.5rem;
-  font-weight: bold;
 `;

--- a/styles/StudyDetailStyle.tsx
+++ b/styles/StudyDetailStyle.tsx
@@ -1,5 +1,7 @@
 import styled from "@emotion/styled";
 
+export const StyledTab = styled.div``;
+
 export const StyledUl = styled("ul")`
   list-style: none;
   display: grid;

--- a/types/postType.ts
+++ b/types/postType.ts
@@ -2,7 +2,7 @@ import type { MouseEventHandler } from "react";
 import type { User } from "./userType";
 
 export interface PostType {
-  id: number;
+  id: string;
   title: string;
   content: string;
   createdAt: string;

--- a/types/postType.ts
+++ b/types/postType.ts
@@ -1,0 +1,13 @@
+import type { MouseEventHandler } from "react";
+import type { User } from "./userType";
+
+export interface PostType {
+  id: number;
+  title: string;
+  content: string;
+  createdAt: string;
+  comments: number;
+  size: number;
+  user: User;
+  onClick?: MouseEventHandler<HTMLElement>;
+}

--- a/types/postType.ts
+++ b/types/postType.ts
@@ -1,5 +1,5 @@
 import type { MouseEventHandler } from "react";
-import type { User } from "./userType";
+import type { UserType } from "./userType";
 
 export interface PostType {
   id: string;
@@ -8,6 +8,6 @@ export interface PostType {
   createdAt: string;
   comments: number;
   size: number;
-  user: User;
+  user: UserType;
   onClick?: MouseEventHandler<HTMLElement>;
 }


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/32607413/183284871-867fc206-73d4-4fa3-9c9a-100cad755378.png">

스터디 상세 페이지에서 post 리스트 보여주기

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

아직 스터디 게시글 관련 API가 없기 때문에 더미 데이터를 사용해서 만들었습니다.

게시글 상세 페이지를 담당하시는 인화님과 얘기해서 post를 클릭할 경우
게시글 id와 현재 tab value를 query로 postDetail 페이지에 전달합니다.
따라서 스터디 상세 페이지와 게시글 상세 페이지의 탭 상태를 공유할 수 있습니다.

** 현재 모바일 반응형은 정상적으로 동작하지 않고 있습니다..ㅠ

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

메인페이지와 동일한 UI 스타일을 사용했습니다. 스타일 관련해서 수정하고 싶으신게 있다면 말씀해주세요


### 🚀 연관된 이슈
close #73 