### PR TITLE
#58/feat/user profile edit with api

### DIFF
--- a/apis/image.ts
+++ b/apis/image.ts
@@ -1,0 +1,14 @@
+import { apiClient } from "./api";
+import { END_POINT } from ".";
+
+export const postImage = async (token: string, file: Blob) => {
+  const formData = new FormData();
+  formData.append("files", file);
+  const { data } = await apiClient.post(`${END_POINT.image}`, formData, {
+    headers: {
+      Authorization: `bearer ${token}`,
+      "Content-Type": "multipart/form-data",
+    },
+  });
+  return data.data.urls[0];
+};

--- a/apis/image.ts
+++ b/apis/image.ts
@@ -1,15 +1,15 @@
 import { apiClient } from "./api";
 import { END_POINT } from ".";
 
+interface IPostImage {
+  urls: string[];
+}
+
 export const postImage = async (token: string, file: Blob) => {
   const formData = new FormData();
   formData.append("files", file);
 
-  interface Itemp {
-    urls: string[];
-  }
-
-  const { urls } = await apiClient.post<Itemp, Itemp>(
+  const { urls } = await apiClient.post<IPostImage, IPostImage>(
     `${END_POINT.image}`,
     formData,
     {
@@ -19,5 +19,6 @@ export const postImage = async (token: string, file: Blob) => {
       },
     }
   );
-  return urls[0];
+  const imageUrl = urls[0]
+  return imageUrl;
 };

--- a/apis/image.ts
+++ b/apis/image.ts
@@ -2,14 +2,18 @@ import { apiClient } from "./api";
 import { END_POINT } from ".";
 
 interface IPostImage {
+  token: string;
+  file: Blob;
+}
+interface PostImageResponse {
   urls: string[];
 }
 
-export const postImage = async (token: string, file: Blob) => {
+export const postImage = async ({ token, file }: IPostImage) => {
   const formData = new FormData();
   formData.append("files", file);
 
-  const { urls } = await apiClient.post<IPostImage, IPostImage>(
+  const { urls } = await apiClient.post<PostImageResponse, PostImageResponse>(
     `${END_POINT.image}`,
     formData,
     {
@@ -19,6 +23,6 @@ export const postImage = async (token: string, file: Blob) => {
       },
     }
   );
-  const imageUrl = urls[0]
+  const imageUrl = urls[0];
   return imageUrl;
 };

--- a/apis/image.ts
+++ b/apis/image.ts
@@ -4,11 +4,20 @@ import { END_POINT } from ".";
 export const postImage = async (token: string, file: Blob) => {
   const formData = new FormData();
   formData.append("files", file);
-  const { data } = await apiClient.post(`${END_POINT.image}`, formData, {
-    headers: {
-      Authorization: `bearer ${token}`,
-      "Content-Type": "multipart/form-data",
-    },
-  });
-  return data.data.urls[0];
+
+  interface Itemp {
+    urls: string[];
+  }
+
+  const { urls } = await apiClient.post<Itemp, Itemp>(
+    `${END_POINT.image}`,
+    formData,
+    {
+      headers: {
+        Authorization: `bearer ${token}`,
+        "Content-Type": "multipart/form-data",
+      },
+    }
+  );
+  return urls[0];
 };

--- a/apis/index.ts
+++ b/apis/index.ts
@@ -1,8 +1,14 @@
 export const END_POINT = {
   book: "/books",
   studies: "/studies",
+  image: "/images",
+  user: "/users",
 };
 
 export { getNaverBooks } from "./naver";
 
 export { getBooksList, getBookInfo, registerBook } from "./book";
+
+export { postImage } from "./image";
+
+export { putUser } from "./user";

--- a/apis/user.ts
+++ b/apis/user.ts
@@ -1,0 +1,22 @@
+import { apiClient } from "./api";
+import { END_POINT } from ".";
+
+export const putUser = async (
+  id: string,
+  name: string,
+  profileImageUrl: string,
+  token: string
+) => {
+  await apiClient.put(
+    `${END_POINT.user}/${id}`,
+    {
+      name,
+      profileImageUrl,
+    },
+    {
+      headers: {
+        Authorization: `bearer ${token}`,
+      },
+    }
+  );
+};

--- a/apis/user.ts
+++ b/apis/user.ts
@@ -7,7 +7,7 @@ export const putUser = async (
   profileImageUrl: string,
   token: string
 ) => {
-  await apiClient.put(
+  const data = await apiClient.put(
     `${END_POINT.user}/${id}`,
     {
       name,
@@ -19,4 +19,5 @@ export const putUser = async (
       },
     }
   );
+  return data;
 };

--- a/apis/user.ts
+++ b/apis/user.ts
@@ -1,17 +1,20 @@
 import { apiClient } from "./api";
 import { END_POINT } from ".";
 
-export const putUser = async (
-  id: string,
-  name: string,
-  profileImageUrl: string,
-  token: string
-) => {
+// TODO 추후 타입 추가
+export interface UserType {
+  id: string;
+  name: string;
+  image: string;
+  token: string;
+}
+
+export const putUser = async ({id, name, image, token}: UserType) => {
   const data = await apiClient.put(
     `${END_POINT.user}/${id}`,
     {
       name,
-      profileImageUrl,
+      image,
     },
     {
       headers: {

--- a/apis/user.ts
+++ b/apis/user.ts
@@ -33,14 +33,14 @@ export const logout = async (token: string) => {
 };
 
 // TODO 추후 타입 추가
-export interface UserType {
+export interface PutUserType {
   id: string;
   name: string;
   image: string;
   token: string;
 }
 
-export const putUser = async ({id, name, image, token}: UserType) => {
+export const putUser = async ({id, name, image, token}: PutUserType) => {
   const data = await apiClient.put(
     `${END_POINT.user}/${id}`,
     {

--- a/pages/userProfileEdit/index.tsx
+++ b/pages/userProfileEdit/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, ChangeEvent } from "react";
 import { useRouter } from "next/router";
 import { Badge } from "@mui/material";
 import { CameraAlt } from "@mui/icons-material";
@@ -21,7 +21,7 @@ const UserProfileEditPage = ({
   const [image, setImage] = useState(profileImageUrl);
   const [imageUrl, setImageUrl] = useState("");
   const [username, setUserName] = useState(name);
-  const imageref = useRef<HTMLInputElement>(null);
+  const imageRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
   const token =
     "eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9MT0dJTiIsInVzZXJJZCI6NywiaWF0IjoxNjU5OTM1MjY2LCJleHAiOjE2NTk5Mzg4NjZ9.6jttoMhex-ylHnqF5W4MXLgYy7sU_0vA8FX5Ulf0cSU";
@@ -32,21 +32,21 @@ const UserProfileEditPage = ({
     if (file) {
       reader.readAsDataURL(file);
       reader.onload = () => setImage(reader.result as string);
-      const imageData = await postImage(token, file);
+      const imageData = await postImage({token, file});
       setImageUrl(imageData);
     }
   };
 
   const handleClickInput = () => {
-    if (imageref.current !== null) imageref.current.click();
+    if (imageRef.current !== null) imageRef.current.click();
   };
 
-  const handleNameChange = (e: any) => {
+  const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => {
     setUserName(e.target.value);
   };
 
   const handleUserInfoUpdate = async () => {
-    await putUser(id, username, imageUrl, token);
+    await putUser({ id, name: username, image: imageUrl, token });
     router.push(`/userProfile/${id}`);
   };
 
@@ -57,7 +57,7 @@ const UserProfileEditPage = ({
   return (
     <S.Container>
       <input
-        ref={imageref}
+        ref={imageRef}
         type="file"
         accept="image/*"
         onChange={handleChangeImage}

--- a/pages/userProfileEdit/index.tsx
+++ b/pages/userProfileEdit/index.tsx
@@ -1,21 +1,80 @@
+import { useState, useRef } from "react";
+import { useRouter } from 'next/router'
+import axios from "axios";
 import { Badge } from "@mui/material";
 import { CameraAlt } from "@mui/icons-material";
+import { postImage, putUser } from "../../apis";
 import * as S from "../../styles/UserProfileEditStyle";
 
 interface UserProfileProps {
+  id: string;
   name: string;
   email: string;
   profileImageUrl: string;
 }
 
 const UserProfileEditPage = ({
+  id = "7",
   name = "사용자 이름",
   email = "1234@naver.com",
-  profileImageUrl = "https://picsum.photos/200",
+  profileImageUrl = "",
 }: UserProfileProps) => {
+  const [image, setImage] = useState(profileImageUrl);
+  const [imageUrl, setImageUrl] = useState("");
+  const [username, setUserName] = useState(name);
+  const imageref = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+  const token =
+    "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjcsInJvbGUiOiJST0xFX0xPR0lOIiwiaWF0IjoxNjU5ODc1NDY4LCJleHAiOjE2NTk4NzkwNjh9.OloP1tFCMH7F7zX_fdYAmnP9-716XLPSiI2m0R83ijQ";
+
+  const handleChangeImage = async (e: any) => {
+    const reader = new FileReader();
+    const [file] = e.target.files;
+    if (file) {
+      reader.readAsDataURL(file);
+      reader.onload = () => setImage(reader.result as string);
+    }
+    // TODO image api 분리 
+    const formData = new FormData();
+    formData.append("files", file);
+    const { data } = await axios.post(
+      `${process.env.NEXT_PUBLIC_API_END_POINT}/images`,
+      formData,
+      {
+        headers: {
+          Authorization: `bearer ${token}`,
+          "Content-Type": "multipart/form-data",
+        },
+      }
+    );
+    // const imagedata = await postImage(token, file)
+    // console.log(imagedata);
+    setImageUrl(data.data.urls[0]);
+  };
+
+  const handleClickInput = () => {
+    if (imageref.current !== null) imageref.current.click();
+  };
+
+  const handleNameChange = (e: any) => {
+    setUserName(e.target.value);
+  };
+
+  const handleUserInfoUpdate = async () => {
+    await putUser(id, name, imageUrl, token);
+    router.push(`/userProfile/${id}`);
+  };
+
   return (
     <S.Container>
-      <S.UserProfileImage>
+      <input
+        ref={imageref}
+        type="file"
+        accept="image/*"
+        onChange={handleChangeImage}
+        style={{ display: "none" }}
+      />
+      <S.UserProfileImage onClick={handleClickInput}>
         <Badge
           overlap="circular"
           anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
@@ -25,10 +84,15 @@ const UserProfileEditPage = ({
             </S.SmallAvatar>
           }
         >
-          <S.StyledAvatar src={profileImageUrl} />
+          <S.StyledAvatar src={image} />
         </Badge>
       </S.UserProfileImage>
-      <S.StyledTextField id="fullWidth" label="이름" defaultValue={name} />
+      <S.StyledTextField
+        value={username}
+        id="fullWidth"
+        label="이름"
+        onChange={handleNameChange}
+      />
       <S.StyledTextField
         disabled
         id="fullWidth"
@@ -36,7 +100,9 @@ const UserProfileEditPage = ({
         defaultValue={email}
       />
       <S.ButtonContainer>
-        <S.StyledButton variant="contained">수정하기</S.StyledButton>
+        <S.StyledButton variant="contained" onClick={handleUserInfoUpdate}>
+          수정하기
+        </S.StyledButton>
         <S.StyledButton variant="contained">뒤로가기</S.StyledButton>
       </S.ButtonContainer>
     </S.Container>

--- a/pages/userProfileEdit/index.tsx
+++ b/pages/userProfileEdit/index.tsx
@@ -1,6 +1,5 @@
-import { useState, useRef } from "react";
-import { useRouter } from 'next/router'
-import axios from "axios";
+import { useState, useRef, useEffect } from "react";
+import { useRouter } from "next/router";
 import { Badge } from "@mui/material";
 import { CameraAlt } from "@mui/icons-material";
 import { postImage, putUser } from "../../apis";
@@ -25,7 +24,7 @@ const UserProfileEditPage = ({
   const imageref = useRef<HTMLInputElement>(null);
   const router = useRouter();
   const token =
-    "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjcsInJvbGUiOiJST0xFX0xPR0lOIiwiaWF0IjoxNjU5ODc1NDY4LCJleHAiOjE2NTk4NzkwNjh9.OloP1tFCMH7F7zX_fdYAmnP9-716XLPSiI2m0R83ijQ";
+    "eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9MT0dJTiIsInVzZXJJZCI6NywiaWF0IjoxNjU5OTM1MjY2LCJleHAiOjE2NTk5Mzg4NjZ9.6jttoMhex-ylHnqF5W4MXLgYy7sU_0vA8FX5Ulf0cSU";
 
   const handleChangeImage = async (e: any) => {
     const reader = new FileReader();
@@ -34,22 +33,8 @@ const UserProfileEditPage = ({
       reader.readAsDataURL(file);
       reader.onload = () => setImage(reader.result as string);
     }
-    // TODO image api 분리 
-    const formData = new FormData();
-    formData.append("files", file);
-    const { data } = await axios.post(
-      `${process.env.NEXT_PUBLIC_API_END_POINT}/images`,
-      formData,
-      {
-        headers: {
-          Authorization: `bearer ${token}`,
-          "Content-Type": "multipart/form-data",
-        },
-      }
-    );
-    // const imagedata = await postImage(token, file)
-    // console.log(imagedata);
-    setImageUrl(data.data.urls[0]);
+    const imageData = await postImage(token, file);
+    setImageUrl(imageData);
   };
 
   const handleClickInput = () => {
@@ -61,9 +46,13 @@ const UserProfileEditPage = ({
   };
 
   const handleUserInfoUpdate = async () => {
-    await putUser(id, name, imageUrl, token);
+    await putUser(id, username, imageUrl, token);
     router.push(`/userProfile/${id}`);
   };
+
+  useEffect(() => {
+    console.log(image);
+  }, [image]);
 
   return (
     <S.Container>

--- a/pages/userProfileEdit/index.tsx
+++ b/pages/userProfileEdit/index.tsx
@@ -32,9 +32,9 @@ const UserProfileEditPage = ({
     if (file) {
       reader.readAsDataURL(file);
       reader.onload = () => setImage(reader.result as string);
+      const imageData = await postImage(token, file);
+      setImageUrl(imageData);
     }
-    const imageData = await postImage(token, file);
-    setImageUrl(imageData);
   };
 
   const handleClickInput = () => {
@@ -51,7 +51,7 @@ const UserProfileEditPage = ({
   };
 
   useEffect(() => {
-    console.log(image);
+    setImageUrl(image);
   }, [image]);
 
   return (

--- a/styles/UserProfileEditStyle.tsx
+++ b/styles/UserProfileEditStyle.tsx
@@ -15,6 +15,8 @@ export const UserProfileImage = styled.div`
 export const StyledAvatar = styled(Avatar)`
   width: 10rem;
   height: 10rem;
+  border: 1px solid #F2F2F2;
+  box-shadow: 12px 21px 15px -3px rgba(0, 0, 0, 0.1);
 `;
 export const SmallAvatar = styled(Avatar)`
   width: "2.5rem";


### PR DESCRIPTION
### 📌 설명
사용자 프로필 수정 구현입니다.

![image](https://user-images.githubusercontent.com/65644486/183346625-034a0eac-c3e9-48d6-87aa-3f10407d2bba.png)

변경 전 postman
![image](https://user-images.githubusercontent.com/65644486/183346357-8590ea45-25a4-4cbc-a4a2-edfa8e2e7b91.png)

변경 후 postman
![image](https://user-images.githubusercontent.com/65644486/183346404-58aaf808-5eec-42ed-8640-1d72506e4941.png)


### 🎨 구현 내용
- 사용자 프로필을 업로드 합니다.

#### 주의할 점
- token을 받아와서 임의로 넣어줘야합니다.
- 현재 postman에서 확인해야합니다.
- 사용자 프로필로 이동하는 router도 연결해놨기때문에 수정하기 누르면 수정되고 404뜨는게 정상입니다.

### ✅ 중점적으로 봐줬으면 하는 부분
에러없는가..?

### 🚀 연관된 이슈
close #58 