### PR TITLE
#90/refactor/topbar

### DIFF
--- a/apis/user.ts
+++ b/apis/user.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { apiClient } from "./api";
 import { END_POINT } from ".";
-import { UserType } from "../types/userType";
+import { TopbarUserType } from "../types/userType";
 
 export const fakeLogin = async () => {
   const data = await axios.get<string>(
@@ -12,7 +12,7 @@ export const fakeLogin = async () => {
 };
 
 export const getMyInfo = async (token: string) => {
-  const data = await apiClient.get<UserType, UserType>(
+  const data = await apiClient.get<TopbarUserType, TopbarUserType>(
     `${END_POINT.getMyInfo}`,
     {
       headers: {
@@ -40,7 +40,7 @@ export interface PutUserType {
   token: string;
 }
 
-export const putUser = async ({id, name, image, token}: PutUserType) => {
+export const putUser = async ({ id, name, image, token }: PutUserType) => {
   const data = await apiClient.put(
     `${END_POINT.user}/${id}`,
     {

--- a/contexts/UserContextProvider.tsx
+++ b/contexts/UserContextProvider.tsx
@@ -1,16 +1,16 @@
 import { createContext, useMemo, useState } from "react";
 import type { ReactNode } from "react";
-import type { UserType } from "../types/userType";
+import type { TopbarUserType } from "../types/userType";
 
 interface UserActionType {
-  login: (inputUser: UserType) => void;
+  login: (inputUser: TopbarUserType) => void;
   logout: () => void;
   openLoginModal: () => void;
   closeLoginModal: () => void;
 }
 
 interface ContextType {
-  user: UserType | null;
+  user: TopbarUserType | null;
   isLoginModalOpen: boolean;
 }
 
@@ -25,7 +25,7 @@ export const UserActionContext = createContext<UserActionType>(
 
 interface UserContextProviderProps {
   children: ReactNode;
-  initialUser: UserType | null;
+  initialUser: TopbarUserType | null;
 }
 
 const UserContextProvider = ({
@@ -38,7 +38,7 @@ const UserContextProvider = ({
   });
   const actions = useMemo(
     () => ({
-      login(inputUser: UserType) {
+      login(inputUser: TopbarUserType) {
         setContext((prevContext) => ({
           ...prevContext,
           user: inputUser,

--- a/contexts/UserContextProvider.tsx
+++ b/contexts/UserContextProvider.tsx
@@ -1,14 +1,24 @@
 import { createContext, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import type { UserType } from "../types/userType";
-import { logout } from "../apis/user";
 
 interface UserActionType {
   login: (inputUser: UserType) => void;
   logout: () => void;
+  openLoginModal: () => void;
+  closeLoginModal: () => void;
 }
 
-export const UserContext = createContext<UserType | null>(null);
+interface ContextType {
+  user: UserType | null;
+  isLoginModalOpen: boolean;
+}
+
+export const UserContext = createContext<ContextType>({
+  user: null,
+  isLoginModalOpen: false,
+});
+
 export const UserActionContext = createContext<UserActionType>(
   {} as UserActionType
 );
@@ -22,14 +32,35 @@ const UserContextProvider = ({
   children,
   initialUser,
 }: UserContextProviderProps) => {
-  const [user, setUser] = useState(initialUser);
+  const [context, setContext] = useState<ContextType>({
+    user: initialUser,
+    isLoginModalOpen: false,
+  });
   const actions = useMemo(
     () => ({
       login(inputUser: UserType) {
-        setUser(inputUser);
+        setContext((prevContext) => ({
+          ...prevContext,
+          user: inputUser,
+        }));
       },
       logout() {
-        setUser(null);
+        setContext((prevContext) => ({
+          ...prevContext,
+          user: null,
+        }));
+      },
+      openLoginModal() {
+        setContext((prevContext) => ({
+          ...prevContext,
+          isLoginModalOpen: true,
+        }));
+      },
+      closeLoginModal() {
+        setContext((prevContext) => ({
+          ...prevContext,
+          isLoginModalOpen: false,
+        }));
       },
     }),
     []
@@ -37,7 +68,7 @@ const UserContextProvider = ({
 
   return (
     <UserActionContext.Provider value={actions}>
-      <UserContext.Provider value={user}>{children}</UserContext.Provider>
+      <UserContext.Provider value={context}>{children}</UserContext.Provider>
     </UserActionContext.Provider>
   );
 };

--- a/features/Topbar/LoginButton/LoginButton.tsx
+++ b/features/Topbar/LoginButton/LoginButton.tsx
@@ -1,16 +1,20 @@
 import { Box, Button, Typography, Modal } from "@mui/material";
 import { useRouter } from "next/router";
-import { useState } from "react";
 import { fakeLogin } from "../../../apis/user";
+import {
+  useUserActionContext,
+  useUserContext,
+} from "../../../hooks/useUserContext";
 import * as S from "./style";
 
 export const LoginButton = () => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { isLoginModalOpen } = useUserContext();
+  const { openLoginModal, closeLoginModal } = useUserActionContext();
   const router = useRouter();
 
-  const handleLoginButtonClick = () => setIsModalOpen(true);
+  const handleLoginButtonClick = () => openLoginModal();
 
-  const handleModalClose = () => setIsModalOpen(false);
+  const handleModalClose = () => closeLoginModal();
 
   const handleFakeLoginClick = async () => {
     const fakeToken = await fakeLogin();
@@ -35,7 +39,7 @@ export const LoginButton = () => {
         로그인
       </Button>
       <Modal
-        open={isModalOpen}
+        open={isLoginModalOpen}
         onClose={handleModalClose}
         aria-labelledby="modal-modal-title"
         aria-describedby="modal-modal-description"

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -17,7 +17,7 @@ const FAKE_QUERY_SIZE = 6;
 
 export const Topbar = () => {
   const router = useRouter();
-  const user = useUserContext();
+  const { user } = useUserContext();
 
   const inputRef = useRef<HTMLInputElement>(null);
   const inputDefaultValue = useRef("");

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -53,10 +53,6 @@ export const Topbar = () => {
     });
   };
 
-  useEffect(() => {
-    if (user) renderSnackbar("로그인에 성공했습니다");
-  }, [user]);
-
   return (
     <S.StyledAppbar position="fixed">
       <Toolbar>

--- a/features/Topbar/UserProfile/UserProfile.tsx
+++ b/features/Topbar/UserProfile/UserProfile.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import type { MouseEvent } from "react";
 import { Avatar, MenuItem, Typography, Button } from "@mui/material";
-import { Folder } from "@mui/icons-material";
 import { useRouter } from "next/router";
 import * as S from "./style";
 import LogoutModal from "./LogoutModal";
@@ -48,12 +47,11 @@ export const UserProfile = () => {
         }}
       >
         <S.AvatarWrapper>
-          <Avatar>
-            <Folder />
-          </Avatar>
+          <Avatar src={user?.image} />
           <S.StyledUserInfo>
             <span>{user?.name}</span>
-            <span>{user?.email}</span>
+            <S.SmallSpan>{user?.email}</S.SmallSpan>
+            <S.SmallSpan>{user?.temperature}℃</S.SmallSpan>
           </S.StyledUserInfo>
         </S.AvatarWrapper>
         <S.StyledDivider />

--- a/features/Topbar/UserProfile/UserProfile.tsx
+++ b/features/Topbar/UserProfile/UserProfile.tsx
@@ -2,20 +2,17 @@ import { useState } from "react";
 import type { MouseEvent } from "react";
 import { Avatar, MenuItem, Typography, Button } from "@mui/material";
 import { Folder } from "@mui/icons-material";
+import { useRouter } from "next/router";
 import * as S from "./style";
 import LogoutModal from "./LogoutModal";
+import { useUserContext } from "../../../hooks/useUserContext";
 
-// TODO Context API 추가 후에 로그아웃은 내려받지 않도록 수정하기
 export const UserProfile = () => {
-  const FAKE_USER_NAME = "고광필";
-  const FAKE_USER_EMAIL = "abcdefghi@naver.com";
-  const FAKE_STUDY_LIST = [
-    { id: 1, title: "이름이 매우매우 매우 매우 매우 매우 긴 스터디" },
-    { id: 2, title: "스터디 2" },
-    { id: 3, title: "스터디 3" },
-  ];
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
   const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
+
+  const router = useRouter();
+  const { user } = useUserContext();
 
   const handleProfileOpen = (event: MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -23,6 +20,10 @@ export const UserProfile = () => {
 
   const handleProfileClose = () => {
     setAnchorEl(null);
+  };
+
+  const handleStudyClick = (studyId: string) => {
+    router.push(`/study/${studyId}`);
   };
 
   const handleLogoutModalOpen = () => {
@@ -51,16 +52,22 @@ export const UserProfile = () => {
             <Folder />
           </Avatar>
           <S.StyledUserInfo>
-            <span>{FAKE_USER_NAME}</span>
-            <span>{FAKE_USER_EMAIL}</span>
+            <span>{user?.name}</span>
+            <span>{user?.email}</span>
           </S.StyledUserInfo>
         </S.AvatarWrapper>
         <S.StyledDivider />
-        {FAKE_STUDY_LIST.map(({ id, title }) => (
-          <MenuItem onClick={handleProfileClose} key={id}>
-            <Typography noWrap>{title}</Typography>
+        {user?.studies.length ? (
+          user.studies.map(({ id, name }) => (
+            <MenuItem onClick={() => handleStudyClick(id)} key={id}>
+              <Typography noWrap>{name}</Typography>
+            </MenuItem>
+          ))
+        ) : (
+          <MenuItem onClick={handleProfileClose}>
+            <Typography noWrap>아직 가입한 스터디가 없습니다</Typography>
           </MenuItem>
-        ))}
+        )}
         <S.StyledDivider />
         <S.LogoutButtonWrapper>
           <Button

--- a/features/Topbar/UserProfile/style.tsx
+++ b/features/Topbar/UserProfile/style.tsx
@@ -1,41 +1,41 @@
-import { styled } from "@mui/material/styles";
 import { Menu, Divider } from "@mui/material";
+import styled from "@emotion/styled";
 
-export const StyledMenu = styled(Menu)(() => ({
-  "& ul": {
-    minWidth: "10rem",
-    maxWidth: "20rem",
-  },
-}));
+export const StyledMenu = styled(Menu)`
+  & ul {
+    min-width: 10rem;
+    max-width: 20rem;
+  }
+`;
 
-export const AvatarWrapper = styled("div")(() => ({
-  display: "flex",
-  padding: "0.5rem 1rem",
-  alignItems: "center",
-  gap: "1rem",
-  width: "fit-content",
-  fontSize: "1.2rem",
-}));
+export const AvatarWrapper = styled("div")`
+  display: flex;
+  padding: 0.5rem 1rem;
+  align-items: center;
+  gap: 1rem;
+  width: fit-content;
+  font-size: 1.2rem;
+`;
 
-export const StyledUserInfo = styled("div")(() => ({
-  display: "flex",
-  flexDirection: "column",
-}));
+export const StyledUserInfo = styled("div")`
+  display: flex;
+  flex-direction: column;
+`;
 
-export const SmallSpan = styled("span")(() => ({
-  fontSize: "0.5rem",
-}));
+export const SmallSpan = styled("span")`
+  font-size: 0.5rem;
+`;
 
-export const StyledDivider = styled(Divider)(() => ({
-  textAlign: "center",
-  margin: "0.5rem 1rem",
-}));
+export const StyledDivider = styled(Divider)`
+  text-align: center;
+  margin: 0.5rem 1rem;
+`;
 
-export const LogoutButtonWrapper = styled("div")(() => ({
-  display: "flex",
-  justifyContent: "end",
-  paddingRight: "1rem",
-}));
+export const LogoutButtonWrapper = styled("div")`
+  display: flex;
+  justify-content: end;
+  padding-right: 1rem;
+`;
 
 export const ButtonContainer = styled("div")`
   display: flex;

--- a/features/Topbar/UserProfile/style.tsx
+++ b/features/Topbar/UserProfile/style.tsx
@@ -20,10 +20,10 @@ export const AvatarWrapper = styled("div")(() => ({
 export const StyledUserInfo = styled("div")(() => ({
   display: "flex",
   flexDirection: "column",
+}));
 
-  "& span:last-child": {
-    fontSize: "0.5rem",
-  },
+export const SmallSpan = styled("span")(() => ({
+  fontSize: "0.5rem",
 }));
 
 export const StyledDivider = styled(Divider)(() => ({

--- a/features/Topbar/style.tsx
+++ b/features/Topbar/style.tsx
@@ -1,77 +1,76 @@
-import { styled, alpha } from "@mui/material/styles";
 import { Typography, InputBase, AppBar } from "@mui/material";
 import { AutoStories } from "@mui/icons-material";
+import styled from "@emotion/styled";
 
-export const StyledAppbar = styled(AppBar)(() => ({
-  backgroundColor: "green",
-}));
+export const StyledAppbar = styled(AppBar)`
+  background-color: green;
+`;
 
-export const LogoIcon = styled(AutoStories)(() => ({
-  marginRight: "0.5rem",
-}));
+export const LogoIcon = styled(AutoStories)`
+  margin-right: 0.5rem;
+`;
 
-export const LogoText = styled(Typography)(({ theme }) => ({
-  marginRight: "0.5rem",
-  display: "flex",
-  fontFamily: "monospace",
-  fontWeight: "700",
-  letterSpacing: "0.3rem",
-  color: "inherit",
-  textDecoration: "none",
+export const LogoText = styled(Typography)`
+  margin-right: 0.5rem;
+  display: flex;
+  font-family: monospace;
+  font-weight: 700;
+  letter-spacing: 0.3rem;
+  color: inherit;
+  text-decoration: none;
 
-  [theme.breakpoints.down("sm")]: {
-    display: "none",
-  },
-}));
+  @media (max-width: 512px) {
+    display: none;
+  }
+`;
 
-export const SearchInputContainer = styled("div")(() => ({
-  flexGrow: 1,
-  display: "flex",
-  justifyContent: "center",
-}));
+export const SearchInputContainer = styled("div")`
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+`;
 
-export const SearchInput = styled("div")(({ theme }) => ({
-  position: "relative",
-  borderRadius: theme.shape.borderRadius,
-  backgroundColor: alpha(theme.palette.common.white, 0.15),
-  marginLeft: 0,
-  width: "100%",
+export const SearchInput = styled("div")`
+  position: relative;
+  border-radius: 0.25rem;
+  background-color: rgba(255, 255, 255, 0.15);
+  margin-left: 0;
+  width: 100%;
 
-  "&:hover": {
-    backgroundColor: alpha(theme.palette.common.white, 0.25),
-  },
+  @media (max-width: 512px) {
+    margin-left: 0.5rem;
+    width: auto;
+  }
 
-  [theme.breakpoints.up("sm")]: {
-    marginLeft: theme.spacing(1),
-    width: "auto",
-  },
-}));
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.25);
+  }
+`;
+export const SearchIconWrapper = styled("div")`
+  padding: 0 1rem;
+  height: 100%;
+  position: absolute;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
 
-export const SearchIconWrapper = styled("div")(({ theme }) => ({
-  padding: theme.spacing(0, 2),
-  height: "100%",
-  position: "absolute",
-  pointerEvents: "none",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-}));
+export const StyledInputBase = styled(InputBase)`
+  color: inherit;
 
-export const StyledInputBase = styled(InputBase)(({ theme }) => ({
-  color: "inherit",
+  & .MuiInputBase-input {
+    padding: 0.5rem;
+    padding-left: calc(1em + 2rem);
+    transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    width: 100%;
 
-  "& .MuiInputBase-input": {
-    padding: theme.spacing(1, 1, 1, 0),
-    paddingLeft: `calc(1em + ${theme.spacing(4)})`,
-    transition: theme.transitions.create("width"),
-    width: "100%",
+    @media (min-width: 512px) {
+      width: 20rem;
 
-    [theme.breakpoints.up("sm")]: {
-      width: "20rem",
-
-      "&:focus": {
-        width: "30rem",
-      },
-    },
-  },
-}));
+      &:focus {
+        width: 30rem;
+      }
+    }
+  }
+`;

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -30,6 +30,7 @@ const LoginPage = () => {
     if (isLoginDone === null) return;
 
     if (isLoginDone) {
+      renderSnackbar("로그인에 성공했습니다");
       router.push("/");
       return;
     }

--- a/types/userType.ts
+++ b/types/userType.ts
@@ -5,3 +5,13 @@ export interface UserType {
   image: string;
   temperature: number;
 }
+
+interface SimpleStudyType {
+  id: string;
+  name: string;
+  thumbnail: string;
+}
+
+export interface TopbarUserType extends UserType {
+  studies: SimpleStudyType[];
+}


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

로그인 ~ 프로필 캡처입니다

![gif](https://user-images.githubusercontent.com/50919342/183470134-ba59a755-8186-414f-a4e6-9ddc617990cd.gif)

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

- 기존에 로그인 버튼을 눌러야 로그인 모달이 나와서 로그인이 가능했는데,
context로 로그인 모달 open 상태를 분리해서 `이 동작은 로그인해야 가능합니다` 하고 띄워줄 수 있습니다
context가 변경되면서 바뀐 코드가 있어서 아래 중점적으로 봐줬으면 하는 부분에 적겠습니다
- Topbar의 UserProfile에서 가짜 데이터를 빼고 로그인한 유저의 정보를 반영했습니다
유저 썸네일, 온도, 가입한 스터디가 없을때 문구도 추가했습니다

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

```
// 기존
const user = useUserContext();

// 변경 후
const { user, isLoginModalOpen } = useUserContext():
```
useUserContext로 user context를 가져오는 로직이 수정되었습니다
현재 dev에는 다른 분들이 유저 정보를 사용하는 로직이 없어서 수정하지 못했습니다
이거 다른분들 반영해주셔야해요!

```
// 주의!
const context = useUserContext();

useEffect(() => {
  if (context.user) console.log('로그인 됨')
}, [context])

// 권장
const { user, isLoginModalOpen } = useUseContext();

useEffect(() => {
  if (user) console.log('로그인 됨');
}, [user])
```
context를 2개를 쓸 때 주의점이 있습니다

구조분해 안하고 한번에 가져와서 useEffect 의존성 배열에 넣으면 user, isLoginModalOpen 하나만 값이 바뀌어도 동작합니다
구조분해하셔서 사용해주세요

### 🚀 연관된 이슈
close issue #90 