### PR TITLE
#88/feat/post create page

### DIFF
--- a/pages/postCreate/index.tsx
+++ b/pages/postCreate/index.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import {
+  MenuItem,
+  TextField,
+  SelectChangeEvent,
+} from "@mui/material";
+import * as S from "../../styles/PostCreatePageStyle";
+
+const PostCreatePage = () => {
+  const [selectValue, setSelectValue] = useState("NOTION");
+  const handleChange = (event: SelectChangeEvent<unknown>) => {
+    setSelectValue(event.target.value as string);
+  };
+  return (
+    <S.Container>
+      <S.Title>
+        <S.StyledSelect
+          labelId="demo-simple-select-label"
+          id="demo-simple-select"
+          value={selectValue}
+          onChange={handleChange}
+        >
+          <MenuItem value="NOTION">공지</MenuItem>
+          <MenuItem value="FREE">자유</MenuItem>
+        </S.StyledSelect>
+        <S.StyledTextField
+          name="title"
+          variant="standard"
+          placeholder="제목을 입력해주세요"
+          margin="dense"
+          fullWidth
+        />
+      </S.Title>
+      <TextField
+        name="content"
+        variant="outlined"
+        placeholder="내용을 입력해주세요"
+        multiline
+        minRows={15}
+        margin="dense"
+      />
+      <S.StyledButton variant="contained">게시하기</S.StyledButton>
+    </S.Container>
+  );
+};
+
+export default PostCreatePage;

--- a/pages/postCreate/index.tsx
+++ b/pages/postCreate/index.tsx
@@ -1,9 +1,5 @@
 import { useState } from "react";
-import {
-  MenuItem,
-  TextField,
-  SelectChangeEvent,
-} from "@mui/material";
+import { MenuItem, TextField, SelectChangeEvent } from "@mui/material";
 import * as S from "../../styles/PostCreatePageStyle";
 
 const PostCreatePage = () => {

--- a/pages/userProfile/[id].tsx
+++ b/pages/userProfile/[id].tsx
@@ -70,7 +70,7 @@ const userProfile = () => {
       ) : (
         <>
           <S.UserProfileContainer>
-            <S.StyledAvatar src={userInfo.profileImageUrl} />
+            <S.StyledAvatar src={userInfo.image} />
             <S.User>
               <S.UserName>{userInfo.name}</S.UserName>
               <S.UserInfo>

--- a/styles/PostCreatePageStyle.tsx
+++ b/styles/PostCreatePageStyle.tsx
@@ -1,0 +1,29 @@
+import styled from "@emotion/styled";
+import { Select, TextField, Button } from "@mui/material";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-item: center;
+`;
+
+export const Title = styled.div`
+  display: flex;
+`;
+
+export const StyledSelect = styled(Select)`
+  width: 10rem;
+  height: 3rem;
+  margin-right: 1rem;
+`;
+
+export const StyledTextField = styled(TextField)`
+  justify-content: flex-end;
+`;
+
+export const StyledButton = styled(Button)`
+  width: 6rem;
+  margin-left: auto;
+  white-space: nowrap;
+`;


### PR DESCRIPTION
### 📌 설명
게시글 생성 페이지 UI 입니다.
/postCreate 로 이동하셔야 볼 수 있습니다.

![image](https://user-images.githubusercontent.com/65644486/183588075-aeea64b6-72d2-47ca-ab13-9f263388a33d.png)

![image](https://user-images.githubusercontent.com/65644486/183588346-fb75539d-c968-4cad-ab41-1fb97c2d6110.png)

### 🎨 구현 내용
- 게시글 생성할 때 쓸 페이지를 만들었습니다.
- 서버가 아직 구현중이라 나중에 붙힐 예정입니다.

mui 공식문서에서 가져온 SelectChangeEvent를 썼더니 타입 에러가 나서 다음과 같이 작성했습니다....
최신 mui에서는 이렇게 작성하라고 stack overflow에 답변이 달려있더군요...
```
  const handleChange = (event: SelectChangeEvent<unknown>) => {
    setSelectValue(event.target.value as string);
  };

```

### ✅ 중점적으로 봐줬으면 하는 부분
디자인 괜찮은가요??

### 🚀 연관된 이슈
close #88 