### PR TITLE
#92/feat/study detail pageapi

### DIFF
--- a/components/Comment/Comment.stories.tsx
+++ b/components/Comment/Comment.stories.tsx
@@ -13,10 +13,11 @@ const Template: ComponentStory<typeof Comment> = (args) => (
 export const Default = Template.bind({});
 Default.args = {
   user: {
-    userId: "TestUser",
+    id: "TestUser",
     name: "user",
     email: "test@naver.com",
-    img: "https://picsum.photos/200",
+    image: "https://picsum.photos/200",
+    temperature: 36.5,
   },
   content: " Lorem ipsum dolor sit ",
 };

--- a/components/Comment/Comment.tsx
+++ b/components/Comment/Comment.tsx
@@ -1,5 +1,5 @@
 import { Avatar } from "@mui/material";
-import { UserType } from "../../types/userType";
+import type { UserType } from "../../types/userType";
 import * as S from "./style";
 
 interface CommentProps {

--- a/components/Comment/Comment.tsx
+++ b/components/Comment/Comment.tsx
@@ -1,9 +1,9 @@
 import { Avatar } from "@mui/material";
-import { User } from "../../types/userType";
+import { UserType } from "../../types/userType";
 import * as S from "./style";
 
 interface CommentProps {
-  user: User;
+  user: UserType;
   content: string;
 }
 
@@ -11,7 +11,7 @@ export const Comment = ({ user, content }: CommentProps) => {
   return (
     <S.CommentContainer>
       <S.UserWrapper>
-        <Avatar src={user.img} /> {user.name}
+        <Avatar src={user.image} /> {user.name}
       </S.UserWrapper>
       <p>{content}</p>
     </S.CommentContainer>

--- a/components/PostCard/PostCard.stories.tsx
+++ b/components/PostCard/PostCard.stories.tsx
@@ -21,10 +21,11 @@ Default.args = {
     comments: 10,
     size: 20,
     user: {
-      userId: "asdasdsa@naver.com",
+      id: "asdasdsa@naver.com",
       name: "김민기",
       email: "asdasdsa@naver.com",
-      img: "https://picsum.photos/200",
+      image: "https://picsum.photos/200",
+      temperature: 36.5,
     },
     onClick: () => {
       console.log("Move PostDetail Page");

--- a/components/PostCard/PostCard.tsx
+++ b/components/PostCard/PostCard.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Badge, Divider } from "@mui/material";
+import { Avatar, Divider } from "@mui/material";
 import ChatIcon from "@mui/icons-material/Chat";
 import type { PostType } from "../../types/postType";
 import * as S from "./style";
@@ -20,9 +20,9 @@ export const PostCard = ({ post }: PostCardProps) => {
           <Avatar src={post.user.image} />
           {post.user.id}
         </S.PostUserWarpper>
-        <Badge badgeContent={post.comments} color="primary">
+        <S.StyledBadge badgeContent={post.comments} color="primary">
           <ChatIcon color="action" />
-        </Badge>
+        </S.StyledBadge>
       </S.PostBottomContainer>
     </S.PostCard>
   );

--- a/components/PostCard/style.tsx
+++ b/components/PostCard/style.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { Badge } from "@mui/material";
 
 interface PostCardProps {
   size: number;
@@ -20,12 +21,13 @@ export const PostTitle = styled.div`
 `;
 
 export const PostContent = styled.div`
+  padding-top: 0.5rem;
   text-overflow: ellipsis;
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  height: 3.5rem;
+  height: 4rem;
 `;
 
 export const PostCreatedAt = styled.div`
@@ -39,6 +41,12 @@ export const PostBottomContainer = styled.div`
   align-items: center;
   justify-content: space-between;
   overflow: hidden;
+`;
+
+export const StyledBadge = styled(Badge)`
+  & .MuiBadge-badge {
+    top: 2px;
+  }
 `;
 
 export const PostUserWarpper = styled.div`

--- a/features/StudyCardList/StudyCardList.tsx
+++ b/features/StudyCardList/StudyCardList.tsx
@@ -23,21 +23,20 @@ export const StudyCardList = ({ studies }: StudyCardListProps) => {
   return (
     <>
       <S.StudyCardContainer>
-        {studies &&
-          studies.map((study) => {
-            return (
-              <Spacer size={1}>
-                <StudyCard
-                  key={study.id}
-                  onClick={() => {
-                    handleStudyClick(study.id);
-                  }}
-                  study={study}
-                  size={128}
-                />
-              </Spacer>
-            );
-          })}
+        {studies?.map((study) => {
+          return (
+            <Spacer size={1}>
+              <StudyCard
+                key={study.id}
+                onClick={() => {
+                  handleStudyClick(study.id);
+                }}
+                study={study}
+                size={128}
+              />
+            </Spacer>
+          );
+        })}
       </S.StudyCardContainer>
 
       <Modal

--- a/features/StudyCardList/StudyCardList.tsx
+++ b/features/StudyCardList/StudyCardList.tsx
@@ -23,20 +23,21 @@ export const StudyCardList = ({ studies }: StudyCardListProps) => {
   return (
     <>
       <S.StudyCardContainer>
-        {studies.map((study) => {
-          return (
-            <Spacer size={1}>
-              <StudyCard
-                key={study.id}
-                onClick={() => {
-                  handleStudyClick(study.id);
-                }}
-                study={study}
-                size={128}
-              />
-            </Spacer>
-          );
-        })}
+        {studies &&
+          studies.map((study) => {
+            return (
+              <Spacer size={1}>
+                <StudyCard
+                  key={study.id}
+                  onClick={() => {
+                    handleStudyClick(study.id);
+                  }}
+                  study={study}
+                  size={128}
+                />
+              </Spacer>
+            );
+          })}
       </S.StudyCardContainer>
 
       <Modal

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,30 +24,32 @@ const Home = ({ books }: ServerSidePropsType) => {
     <S.MainPageWrapper>
       <S.StyledSpan>가장 최근 추가된 책</S.StyledSpan>
       <S.StyledUl>
-        {latestBooks.map((book) => (
-          <S.StyledList key={book.id}>
-            <BookCard
-              src={book.image}
-              title=""
-              size={10}
-              onClick={() => handleBookCardClick(book.id)}
-            />
-          </S.StyledList>
-        ))}
+        {latestBooks &&
+          latestBooks.map((book) => (
+            <S.StyledList key={book.id}>
+              <BookCard
+                src={book.image}
+                title=""
+                size={10}
+                onClick={() => handleBookCardClick(book.id)}
+              />
+            </S.StyledList>
+          ))}
       </S.StyledUl>
 
       <S.StyledSpan>가장 최근 스터디가 만들어진 책</S.StyledSpan>
       <S.StyledUl>
-        {studyLatestBooks.map((book) => (
-          <S.StyledList key={book.id}>
-            <BookCard
-              src={book.image}
-              title=""
-              size={10}
-              onClick={() => handleBookCardClick(book.id)}
-            />
-          </S.StyledList>
-        ))}
+        {studyLatestBooks &&
+          studyLatestBooks.map((book) => (
+            <S.StyledList key={book.id}>
+              <BookCard
+                src={book.image}
+                title=""
+                size={10}
+                onClick={() => handleBookCardClick(book.id)}
+              />
+            </S.StyledList>
+          ))}
       </S.StyledUl>
     </S.MainPageWrapper>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,32 +24,30 @@ const Home = ({ books }: ServerSidePropsType) => {
     <S.MainPageWrapper>
       <S.StyledSpan>가장 최근 추가된 책</S.StyledSpan>
       <S.StyledUl>
-        {latestBooks &&
-          latestBooks.map((book) => (
-            <S.StyledList key={book.id}>
-              <BookCard
-                src={book.image}
-                title=""
-                size={10}
-                onClick={() => handleBookCardClick(book.id)}
-              />
-            </S.StyledList>
-          ))}
+        {latestBooks?.map((book) => (
+          <S.StyledList key={book.id}>
+            <BookCard
+              src={book.image}
+              title=""
+              size={10}
+              onClick={() => handleBookCardClick(book.id)}
+            />
+          </S.StyledList>
+        ))}
       </S.StyledUl>
 
       <S.StyledSpan>가장 최근 스터디가 만들어진 책</S.StyledSpan>
       <S.StyledUl>
-        {studyLatestBooks &&
-          studyLatestBooks.map((book) => (
-            <S.StyledList key={book.id}>
-              <BookCard
-                src={book.image}
-                title=""
-                size={10}
-                onClick={() => handleBookCardClick(book.id)}
-              />
-            </S.StyledList>
-          ))}
+        {studyLatestBooks?.map((book) => (
+          <S.StyledList key={book.id}>
+            <BookCard
+              src={book.image}
+              title=""
+              size={10}
+              onClick={() => handleBookCardClick(book.id)}
+            />
+          </S.StyledList>
+        ))}
       </S.StyledUl>
     </S.MainPageWrapper>
   );

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -52,21 +52,38 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
     router.push(`/postCreate`, { query: { tabNumber } });
   };
 
-  return (
-    <>
-      <StudyDetailCard study={study} members={members} />
-      <Tabs value={tabNumber} onChange={handleTabChange}>
-        <Tab label="공지" />
-        <Tab label="자유" />
-        {isOwner && <Tab label="관리자" />}
-      </Tabs>
-      <TabPanel value={tabNumber} index={0}>
-        {isOwner && (
+  const writeButton = () => {
+    if (tabNumber !== 2)
+      if (tabNumber === 0) {
+        if (isOwner)
+          return (
+            <Button variant="contained" onClick={handleButtonClick}>
+              글 작성
+            </Button>
+          );
+      } else
+        return (
           <Button variant="contained" onClick={handleButtonClick}>
             글 작성
           </Button>
-        )}
+        );
 
+    return "";
+  };
+
+  return (
+    <>
+      <StudyDetailCard study={study} members={members} />
+      <S.TabsWrapper>
+        <Tabs value={tabNumber} onChange={handleTabChange}>
+          <Tab label="공지" />
+          <Tab label="자유" />
+          {isOwner && <Tab label="관리자" />}
+        </Tabs>
+        {writeButton()}
+      </S.TabsWrapper>
+
+      <TabPanel value={tabNumber} index={0}>
         <S.StyledUl>
           {DummyPost.map((post) => (
             <S.StyledList
@@ -81,9 +98,6 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
         </S.StyledUl>
       </TabPanel>
       <TabPanel value={tabNumber} index={1}>
-        <Button variant="contained" onClick={handleButtonClick}>
-          글 작성
-        </Button>
         <S.StyledUl>
           {DummyPost.map((post) => (
             <S.StyledList

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -23,6 +23,29 @@ interface ServerSidePropType {
 
 const STUDY_OWNER = 0;
 
+const writeButton = (
+  tabNumber: number,
+  isOwner: boolean,
+  onButtonClick: () => void
+) => {
+  if (tabNumber !== 2)
+    if (tabNumber === 0) {
+      if (isOwner)
+        return (
+          <Button variant="contained" onClick={onButtonClick}>
+            글 작성
+          </Button>
+        );
+    } else
+      return (
+        <Button variant="contained" onClick={onButtonClick}>
+          글 작성
+        </Button>
+      );
+
+  return "";
+};
+
 const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
   const { study, members } = studyData;
 
@@ -45,30 +68,17 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
   };
 
   const handlePostClick = (id: number) => {
-    router.push(`/postDetail/${id}`, { query: { tabNumber } });
+    router.push({
+      pathname: `/post/${id}`,
+      query: { tabNumber },
+    });
   };
 
   const handleButtonClick = () => {
-    router.push(`/postCreate`, { query: { tabNumber } });
-  };
-
-  const writeButton = () => {
-    if (tabNumber !== 2)
-      if (tabNumber === 0) {
-        if (isOwner)
-          return (
-            <Button variant="contained" onClick={handleButtonClick}>
-              글 작성
-            </Button>
-          );
-      } else
-        return (
-          <Button variant="contained" onClick={handleButtonClick}>
-            글 작성
-          </Button>
-        );
-
-    return "";
+    router.push({
+      pathname: `/postCreate`,
+      query: { tabNumber },
+    });
   };
 
   return (
@@ -80,9 +90,9 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
           <Tab label="자유" />
           {isOwner && <Tab label="관리자" />}
         </Tabs>
-        {writeButton()}
+        {writeButton(tabNumber, isOwner, handleButtonClick)}
       </S.TabsWrapper>
-
+      {/* TODO 더미 데이터 사용중 교체 예정 */}
       <TabPanel value={tabNumber} index={0}>
         <S.StyledUl>
           {DummyPost.map((post) => (

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useEffect, useState } from "react";
+import type { SyntheticEvent } from "react";
 import { Tabs, Tab, Button } from "@mui/material";
 import type { GetServerSideProps } from "next/types";
 import { useRouter } from "next/router";
@@ -23,21 +24,26 @@ interface ServerSidePropType {
 const STUDY_OWNER = 0;
 
 const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
-  const router = useRouter();
-  // TODO studyID를 사용하지 않는 다면 삭제
-  const { id: studyID, value: tabValue } = router.query;
-  const currentTab = tabValue ? parseInt(tabValue as string, 10) : 0;
-  const { user } = useUserContext();
-  const [tabNumber, setTabNumber] = useState(currentTab);
   const { study, members } = studyData;
-  const userID = user?.id;
-  const ownerID = members[STUDY_OWNER].id;
-  const handleTabChange = (e: React.SyntheticEvent, newValue: number) => {
+
+  const router = useRouter();
+  const { value: tabValue } = router.query;
+  const currentTab = tabValue ? parseInt(tabValue as string, 10) : 0;
+  const [tabNumber, setTabNumber] = useState(currentTab);
+
+  const [isOwner, setIsOwner] = useState(false);
+
+  const { user } = useUserContext();
+
+  useEffect(() => {
+    if (user?.id === members[STUDY_OWNER].id) setIsOwner(true);
+    else setIsOwner(false);
+  }, [user]);
+
+  const handleTabChange = (e: SyntheticEvent, newValue: number) => {
     setTabNumber(newValue);
   };
 
-  // TODO 게시글 클릭 시 value 값을 갖고 게시글 상세 페이지로 이동 확인
-  // TODO API 연동 확인
   const handlePostClick = (id: number) => {
     router.push(`/boardDetail/${id}`, { query: { tabNumber } });
   };
@@ -46,24 +52,19 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
     router.push(`/postCreate`, { query: { tabNumber } });
   };
 
-  // TODO 관리자 탭 0,1 모두 작성 가능
-  // TODO 일반 참가자 1번 탭만 작성 가능
-
   return (
     <>
       <StudyDetailCard study={study} members={members} />
       <Tabs value={tabNumber} onChange={handleTabChange}>
         <Tab label="공지" />
         <Tab label="자유" />
-        {userID === ownerID ? <Tab label="관리자" /> : ""}
+        {isOwner && <Tab label="관리자" />}
       </Tabs>
       <TabPanel value={tabNumber} index={0}>
-        {userID === ownerID ? (
+        {isOwner && (
           <Button variant="contained" onClick={handleButtonClick}>
             글 작성
           </Button>
-        ) : (
-          ""
         )}
 
         <S.StyledUl>

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -45,7 +45,7 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
   };
 
   const handlePostClick = (id: number) => {
-    router.push(`/boardDetail/${id}`, { query: { tabNumber } });
+    router.push(`/postDetail/${id}`, { query: { tabNumber } });
   };
 
   const handleButtonClick = () => {

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -8,8 +8,8 @@ import { StudyDetailCard } from "../../components/StudyDetailCard";
 import { getStudyDetailInfo } from "../../apis/study";
 import { PostCard } from "../../components/PostCard";
 import { DummyPost } from "../../commons/dummyPost";
-import * as S from "../../styles/StudyDetailPageStyle";
 import { useUserContext } from "../../hooks/useUserContext";
+import * as S from "../../styles/StudyDetailPageStyle";
 
 interface ServerSidePropType {
   studyData: StudyDetailType;
@@ -27,7 +27,7 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
   // TODO studyID를 사용하지 않는 다면 삭제
   const { id: studyID, value: tabValue } = router.query;
   const currentTab = tabValue ? parseInt(tabValue as string, 10) : 0;
-  const user = useUserContext();
+  const { user } = useUserContext();
   const [tabNumber, setTabNumber] = useState(currentTab);
   const { study, members } = studyData;
   const userID = user?.id;
@@ -42,6 +42,10 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
     router.push(`/boardDetail/${id}`, { query: { tabNumber } });
   };
 
+  const handleButtonClick = () => {
+    router.push(`/postCreate`, { query: { tabNumber } });
+  };
+
   // TODO 관리자 탭 0,1 모두 작성 가능
   // TODO 일반 참가자 1번 탭만 작성 가능
 
@@ -54,22 +58,39 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
         {userID === ownerID ? <Tab label="관리자" /> : ""}
       </Tabs>
       <TabPanel value={tabNumber} index={0}>
-        <Button variant="contained" disabled={userID !== ownerID}>
-          글 작성
-        </Button>
+        {userID === ownerID ? (
+          <Button variant="contained" onClick={handleButtonClick}>
+            글 작성
+          </Button>
+        ) : (
+          ""
+        )}
+
         <S.StyledUl>
           {DummyPost.map((post) => (
-            <S.StyledList key={post.id}>
+            <S.StyledList
+              key={post.id}
+              onClick={() => {
+                handlePostClick(+post.id);
+              }}
+            >
               <PostCard post={post} />
             </S.StyledList>
           ))}
         </S.StyledUl>
       </TabPanel>
       <TabPanel value={tabNumber} index={1}>
-        <Button variant="contained">글 작성</Button>
+        <Button variant="contained" onClick={handleButtonClick}>
+          글 작성
+        </Button>
         <S.StyledUl>
           {DummyPost.map((post) => (
-            <S.StyledList key={post.id}>
+            <S.StyledList
+              key={post.id}
+              onClick={() => {
+                handlePostClick(+post.id);
+              }}
+            >
               <PostCard post={post} />
             </S.StyledList>
           ))}
@@ -78,7 +99,12 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
       <TabPanel value={tabNumber} index={2}>
         <S.StyledUl>
           {DummyPost.map((post) => (
-            <S.StyledList key={post.id}>
+            <S.StyledList
+              key={post.id}
+              onClick={() => {
+                handlePostClick(+post.id);
+              }}
+            >
               <PostCard post={post} />
             </S.StyledList>
           ))}

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -28,12 +28,12 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
   const { id: studyID, value: tabValue } = router.query;
   const currentTab = tabValue ? parseInt(tabValue as string, 10) : 0;
   const user = useUserContext();
-  const [tabNumber, setTabValue] = useState(currentTab);
+  const [tabNumber, setTabNumber] = useState(currentTab);
   const { study, members } = studyData;
-  console.log("user", user);
-  console.log("owner", members[STUDY_OWNER]);
+  const userID = user?.id;
+  const ownerID = members[STUDY_OWNER].id;
   const handleTabChange = (e: React.SyntheticEvent, newValue: number) => {
-    setTabValue(newValue);
+    setTabNumber(newValue);
   };
 
   // TODO 게시글 클릭 시 value 값을 갖고 게시글 상세 페이지로 이동 확인
@@ -41,18 +41,22 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
   const handlePostClick = (id: number) => {
     router.push(`/boardDetail/${id}`, { query: { tabNumber } });
   };
+
+  // TODO 관리자 탭 0,1 모두 작성 가능
+  // TODO 일반 참가자 1번 탭만 작성 가능
+
   return (
     <>
       <StudyDetailCard study={study} members={members} />
-      <S.TabsWrapper>
-        <Tabs value={tabNumber} onChange={handleTabChange}>
-          <Tab label="공지" />
-          <Tab label="자유" />
-          <Tab label="관리자" disabled />
-        </Tabs>
-        <Button variant="contained">글쓰기</Button>
-      </S.TabsWrapper>
+      <Tabs value={tabNumber} onChange={handleTabChange}>
+        <Tab label="공지" />
+        <Tab label="자유" />
+        {userID === ownerID ? <Tab label="관리자" /> : ""}
+      </Tabs>
       <TabPanel value={tabNumber} index={0}>
+        <Button variant="contained" disabled={userID !== ownerID}>
+          글 작성
+        </Button>
         <S.StyledUl>
           {DummyPost.map((post) => (
             <S.StyledList key={post.id}>
@@ -62,6 +66,7 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
         </S.StyledUl>
       </TabPanel>
       <TabPanel value={tabNumber} index={1}>
+        <Button variant="contained">글 작성</Button>
         <S.StyledUl>
           {DummyPost.map((post) => (
             <S.StyledList key={post.id}>

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -44,13 +44,14 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
   return (
     <>
       <StudyDetailCard study={study} members={members} />
-      
-      <Tabs value={tabNumber} onChange={handleTabChange}>
-        <Tab label="공지" />
-        <Tab label="자유" />
-        <Tab label="관리자" disabled />
-      </Tabs>
-      <Button variant="contained">글쓰기</Button>
+      <S.TabsWrapper>
+        <Tabs value={tabNumber} onChange={handleTabChange}>
+          <Tab label="공지" />
+          <Tab label="자유" />
+          <Tab label="관리자" disabled />
+        </Tabs>
+        <Button variant="contained">글쓰기</Button>
+      </S.TabsWrapper>
       <TabPanel value={tabNumber} index={0}>
         <S.StyledUl>
           {DummyPost.map((post) => (

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Tabs, Tab } from "@mui/material";
+import { Tabs, Tab, Button } from "@mui/material";
 import type { GetServerSideProps } from "next/types";
 import { useRouter } from "next/router";
 import type { StudyDetailType } from "../../types/studyType";
@@ -9,19 +9,29 @@ import { getStudyDetailInfo } from "../../apis/study";
 import { PostCard } from "../../components/PostCard";
 import { DummyPost } from "../../commons/dummyPost";
 import * as S from "../../styles/StudyDetailPageStyle";
+import { useUserContext } from "../../hooks/useUserContext";
 
 interface ServerSidePropType {
   studyData: StudyDetailType;
 }
 
+// TODO ContextAPI로 User 정보 가져오기
+// TODO studyID로 Study 정보 요청하기
+// TODO 게시글 작성 버튼
+// TODO User가 스터디장일 경우와 아닐 경우 탭, 버튼 권한 부여
+
+const STUDY_OWNER = 0;
+
 const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
-  // TODO router에 value query가 있으면 setValue로 실행.
   const router = useRouter();
+  // TODO studyID를 사용하지 않는 다면 삭제
   const { id: studyID, value: tabValue } = router.query;
   const currentTab = tabValue ? parseInt(tabValue as string, 10) : 0;
-
+  const user = useUserContext();
   const [tabNumber, setTabValue] = useState(currentTab);
   const { study, members } = studyData;
+  console.log("user", user);
+  console.log("owner", members[STUDY_OWNER]);
   const handleTabChange = (e: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
   };
@@ -34,41 +44,40 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
   return (
     <>
       <StudyDetailCard study={study} members={members} />
-
+      
       <Tabs value={tabNumber} onChange={handleTabChange}>
         <Tab label="공지" />
         <Tab label="자유" />
         <Tab label="관리자" disabled />
       </Tabs>
-      <S.StyledTab>
-        <TabPanel value={tabNumber} index={0}>
-          <S.StyledUl>
-            {DummyPost.map((post) => (
-              <S.StyledList key={post.id}>
-                <PostCard post={post} />
-              </S.StyledList>
-            ))}
-          </S.StyledUl>
-        </TabPanel>
-        <TabPanel value={tabNumber} index={1}>
-          <S.StyledUl>
-            {DummyPost.map((post) => (
-              <S.StyledList key={post.id}>
-                <PostCard post={post} />
-              </S.StyledList>
-            ))}
-          </S.StyledUl>
-        </TabPanel>
-        <TabPanel value={tabNumber} index={2}>
-          <S.StyledUl>
-            {DummyPost.map((post) => (
-              <S.StyledList key={post.id}>
-                <PostCard post={post} />
-              </S.StyledList>
-            ))}
-          </S.StyledUl>
-        </TabPanel>
-      </S.StyledTab>
+      <Button variant="contained">글쓰기</Button>
+      <TabPanel value={tabNumber} index={0}>
+        <S.StyledUl>
+          {DummyPost.map((post) => (
+            <S.StyledList key={post.id}>
+              <PostCard post={post} />
+            </S.StyledList>
+          ))}
+        </S.StyledUl>
+      </TabPanel>
+      <TabPanel value={tabNumber} index={1}>
+        <S.StyledUl>
+          {DummyPost.map((post) => (
+            <S.StyledList key={post.id}>
+              <PostCard post={post} />
+            </S.StyledList>
+          ))}
+        </S.StyledUl>
+      </TabPanel>
+      <TabPanel value={tabNumber} index={2}>
+        <S.StyledUl>
+          {DummyPost.map((post) => (
+            <S.StyledList key={post.id}>
+              <PostCard post={post} />
+            </S.StyledList>
+          ))}
+        </S.StyledUl>
+      </TabPanel>
     </>
   );
 };

--- a/styles/StudyDetailPageStyle.tsx
+++ b/styles/StudyDetailPageStyle.tsx
@@ -1,6 +1,12 @@
 import styled from "@emotion/styled";
 
-export const StyledUl = styled("ul")`
+export const TabsWrapper = styled.div`
+  margin: 1rem 0.5rem;
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const StyledUl = styled.ul`
   list-style: none;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
@@ -13,7 +19,7 @@ export const StyledUl = styled("ul")`
   }
 `;
 
-export const StyledList = styled("li")`
+export const StyledList = styled.li`
   justify-self: center;
   &:hover {
     transform: scale(1.05) translateY(-10px);

--- a/styles/StudyDetailPageStyle.tsx
+++ b/styles/StudyDetailPageStyle.tsx
@@ -1,11 +1,5 @@
 import styled from "@emotion/styled";
 
-export const TabsWrapper = styled.div`
-  margin: 1rem 0.5rem;
-  display: flex;
-  justify-content: space-between;
-`;
-
 export const StyledUl = styled.ul`
   list-style: none;
   display: grid;

--- a/styles/StudyDetailPageStyle.tsx
+++ b/styles/StudyDetailPageStyle.tsx
@@ -1,5 +1,11 @@
 import styled from "@emotion/styled";
 
+export const TabsWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin: 1rem;
+`;
+
 export const StyledUl = styled.ul`
   list-style: none;
   display: grid;


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

### 스터디장일 경우

![Kapture 2022-08-09 at 18 23 01](https://user-images.githubusercontent.com/32607413/183613852-66a96d23-a7fd-4bf8-914c-4b5bc474b13a.gif)


### 일반 스터디원일 경우

![Kapture 2022-08-09 at 18 21 39](https://user-images.githubusercontent.com/32607413/183613622-129563c4-8460-47cf-93cd-9d5d0688235a.gif)


### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

dev를 머지해서 useUserContext을 사용해서 구조분해 할당으로 user를 가져옵니다.
study 상세 정보는 study/[id] 페이지에 접속할 때 서버사이드로부터 넘겨 받은 데이터를 사용합니다.
현재 유저와 스터디 상세정보에 있는 member의 0번째 유저가 같을 경우 스터디장으로 인식하고
공지, 자유, 관리자 탭에 접근 가능합니다.

만약 일반 스터디원일 경우 공지 탭은 확인만 가능하며, 자유 게시판에서만 글 작성을 할 수 있습니다.

글 작성 버튼 클릭시 `router.push(`/postCreate`, { query: { tabNumber } });` 을 실행합니다.
tabNumber는 어떤 탭에서 글 작성 버튼을 눌렀는지 구분하기 위함입니다. (필요 없다면 삭제하겠습니다.)

게시글을 클릭할 경우 게시글 상세 페이지로 이동합니다. (postDetail)

추가적으로 type 관련해서 PR 올라온 내용 바탕으로 Comment, PostCard에서 타입 수정했습니다.


### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

글 작성 버튼 위치를 어디에 두는게 좋을까요?? 

### 🚀 연관된 이슈
close #92 