### PR TITLE
#71/refactor/search page

### DIFF
--- a/apis/book.ts
+++ b/apis/book.ts
@@ -12,12 +12,16 @@ export const registerBook = async (
   book: NaverBookType,
   accessToken: string
 ) => {
-  const data = await apiClient.put(`${END_POINT.book}`, JSON.stringify(book), {
-    headers: {
-      Authorization: `bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
-  });
+  const data = await apiClient.post<number, number>(
+    `${END_POINT.book}`,
+    JSON.stringify(book),
+    {
+      headers: {
+        Authorization: `bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    }
+  );
 
   return data;
 };

--- a/apis/book.ts
+++ b/apis/book.ts
@@ -29,3 +29,10 @@ export const getBookInfo = async (bookId: string) => {
 
   return data;
 };
+
+export const getBookInfoByISBN = async (isbn: string) => {
+  const data = await apiClient.get<BookType, BookType>(
+    `${END_POINT.isbnBook}/${isbn}`
+  );
+  return data;
+};

--- a/apis/index.ts
+++ b/apis/index.ts
@@ -6,6 +6,7 @@ export const END_POINT = {
   fakeLogin: "/tokens/7",
   getMyInfo: "/me",
   logout: "/logout",
+  isbnBook: "/books/isbn",
 };
 
 export { getNaverBooks } from "./naver";

--- a/apis/naver.ts
+++ b/apis/naver.ts
@@ -1,14 +1,11 @@
 import axios from "axios";
 import type { NaverBookResponseType } from "../types/bookType";
 
-const DISPLAY = 10;
-
 export const getNaverBooks = async (query: string, start = 1) => {
   try {
     const res = await axios.get<NaverBookResponseType>("/naver", {
       params: {
         query,
-        display: DISPLAY,
         start,
       },
       headers: {

--- a/apis/naver.ts
+++ b/apis/naver.ts
@@ -1,14 +1,15 @@
 import axios from "axios";
+import type { NaverBookResponseType } from "../types/bookType";
 
-// (네이버에서 계산한) 유사도에 의한 책 조회
-// title, author, isbn 등...
-export const getNaverBooks = async (query: string, count = 10, offset = 1) => {
+const display = 10;
+
+export const getNaverBooks = async (query: string, start = 1) => {
   try {
-    const res = await axios.get("/naver", {
+    const res = await axios.get<NaverBookResponseType>("/naver", {
       params: {
         query,
-        display: count,
-        start: offset,
+        display,
+        start,
       },
       headers: {
         "X-Naver-Client-Id": process.env

--- a/apis/naver.ts
+++ b/apis/naver.ts
@@ -1,14 +1,14 @@
 import axios from "axios";
 import type { NaverBookResponseType } from "../types/bookType";
 
-const display = 10;
+const DISPLAY = 10;
 
 export const getNaverBooks = async (query: string, start = 1) => {
   try {
     const res = await axios.get<NaverBookResponseType>("/naver", {
       params: {
         query,
-        display,
+        display: DISPLAY,
         start,
       },
       headers: {

--- a/features/SearchPageModal/SearchPageModal.tsx
+++ b/features/SearchPageModal/SearchPageModal.tsx
@@ -1,0 +1,45 @@
+import { Button, Modal, Typography } from "@mui/material";
+import { useUserActionContext } from "../../hooks/useUserContext";
+import * as S from "./style";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const SearchPageModal = ({ open, onClose }: Props) => {
+  const { openLoginModal } = useUserActionContext();
+
+  const handleLoginClick = () => {
+    onClose();
+    openLoginModal();
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      aria-labelledby="searchPage-modal-title"
+      aria-describedby="searchPage-modal-description"
+      disableEnforceFocus
+    >
+      <S.ModalContentContainer>
+        <Typography id="searchPage-modal-title" variant="h6" component="h2">
+          이 책은 등록되지 않은 책입니다
+        </Typography>
+        <S.ModalDescription id="searchPage-modal-description">
+          책모이에 책을 등록해주세요
+          <br />책 등록은 회원만 가능합니다 로그인하시겠습니까?
+        </S.ModalDescription>
+        <S.ButtonContainer>
+          <Button variant="contained" onClick={handleLoginClick}>
+            로그인
+          </Button>
+          <Button variant="contained" onClick={onClose}>
+            닫기
+          </Button>
+        </S.ButtonContainer>
+      </S.ModalContentContainer>
+    </Modal>
+  );
+};

--- a/features/SearchPageModal/SearchPageModal.tsx
+++ b/features/SearchPageModal/SearchPageModal.tsx
@@ -2,12 +2,12 @@ import { Button, Modal, Typography } from "@mui/material";
 import { useUserActionContext } from "../../hooks/useUserContext";
 import * as S from "./style";
 
-interface Props {
+interface SearchPageModalProps {
   open: boolean;
   onClose: () => void;
 }
 
-export const SearchPageModal = ({ open, onClose }: Props) => {
+export const SearchPageModal = ({ open, onClose }: SearchPageModalProps) => {
   const { openLoginModal } = useUserActionContext();
 
   const handleLoginClick = () => {

--- a/features/SearchPageModal/index.tsx
+++ b/features/SearchPageModal/index.tsx
@@ -1,0 +1,1 @@
+export { SearchPageModal } from "./SearchPageModal";

--- a/features/SearchPageModal/style.tsx
+++ b/features/SearchPageModal/style.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+
+export const ModalContentContainer = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 400;
+  background-color: white;
+  box-shadow: 0px 11px 15px -7px rgb(0 0 0 / 20%),
+    0px 24px 38px 3px rgb(0 0 0 / 14%), 0px 9px 46px 8px rgb(0 0 0 / 12%);
+  padding: 2rem;
+`;
+
+export const ButtonContainer = styled("div")`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const ModalDescription = styled.p`
+  margin: 1rem 0;
+`;

--- a/features/SearchPageModal/style.tsx
+++ b/features/SearchPageModal/style.tsx
@@ -12,7 +12,7 @@ export const ModalContentContainer = styled.div`
   padding: 2rem;
 `;
 
-export const ButtonContainer = styled("div")`
+export const ButtonContainer = styled.div`
   display: flex;
   justify-content: space-between;
 `;

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import type { FormEvent } from "react";
 import { Toolbar } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
@@ -10,10 +10,8 @@ import { LoginButton } from "./LoginButton";
 import { useUserContext } from "../../hooks/useUserContext";
 import { useOurSnackbar } from "../../hooks/useOurSnackbar";
 
-// TODO 사용자 정보 불러오기
-
-const FAKE_URL = "/search";
-const FAKE_QUERY_SIZE = 6;
+const SEARCH_URL = "/search";
+const SEARCH_URL_SIZE = 6;
 
 export const Topbar = () => {
   const router = useRouter();
@@ -24,11 +22,10 @@ export const Topbar = () => {
   const isClientWindow = typeof window !== "undefined";
 
   if (isClientWindow)
-    if (window.location.pathname === FAKE_URL) {
-      // TODO FAKE_URL 수정 시 FAKE_QUERY_SIZE 수정
+    if (window.location.pathname === SEARCH_URL) {
       const urlWord = window.location.search
         ?.split("&")[0]
-        ?.slice(FAKE_QUERY_SIZE)
+        ?.slice(SEARCH_URL_SIZE)
         .replaceAll("+", " ")
         .trim();
       inputDefaultValue.current = decodeURIComponent(urlWord);
@@ -49,7 +46,7 @@ export const Topbar = () => {
     }
 
     router.push({
-      pathname: FAKE_URL,
+      pathname: SEARCH_URL,
       query: {
         word,
         page: 1,

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -27,7 +27,8 @@ export const Topbar = () => {
     if (window.location.pathname === FAKE_URL) {
       // TODO FAKE_URL 수정 시 FAKE_QUERY_SIZE 수정
       const urlWord = window.location.search
-        .slice(FAKE_QUERY_SIZE)
+        ?.split("&")[0]
+        ?.slice(FAKE_QUERY_SIZE)
         .replaceAll("+", " ")
         .trim();
       inputDefaultValue.current = decodeURIComponent(urlWord);
@@ -49,7 +50,10 @@ export const Topbar = () => {
 
     router.push({
       pathname: FAKE_URL,
-      query: { word },
+      query: {
+        word,
+        page: 1,
+      },
     });
   };
 

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -38,9 +38,13 @@ const SearchPage = () => {
       return;
     }
 
-    const [_, token] = document.cookie.split("token=");
-    const registeredBookId = await registerBook(book, token);
-    router.push(`/book/${registeredBookId}`);
+    try {
+      const [_, token] = document.cookie.split("token=");
+      const registeredBookId = await registerBook(book, token);
+      router.push(`/book/${registeredBookId}`);
+    } catch (error) {
+      renderSnackbar("책 등록에 실패했습니다", "error");
+    }
   };
 
   const handleBookCardClick = async (book: NaverBookType) => {

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -9,6 +9,9 @@ import * as S from "../../styles/SearchPageStyle";
 import { getBookInfoByISBN } from "../../apis/book";
 import type { ErrorResponseType } from "../../types/errorTypes";
 import { useOurSnackbar } from "../../hooks/useOurSnackbar";
+import { useUserContext } from "../../hooks/useUserContext";
+import type { TopbarUserType } from "../../types/userType";
+import { SearchPageModal } from "../../features/SearchPageModal";
 
 const SEARCH_URL = "/search";
 
@@ -18,8 +21,19 @@ const SearchPage = () => {
 
   const [loading, setLoading] = useState(true);
   const [searchedInfo, setSearchedInfo] = useState({} as NaverBookResponseType);
+  const [isSearchPageModalOpen, setIsSearchPageModalOpen] = useState(false);
 
   const { renderSnackbar } = useOurSnackbar();
+  const { user } = useUserContext();
+
+  const registerBook = (inputUser: TopbarUserType | null) => {
+    if (inputUser) {
+      console.log("로그인");
+      console.log(inputUser);
+      return;
+    }
+    setIsSearchPageModalOpen(true);
+  };
 
   const handleBookCardClick = async (isbn: string) => {
     try {
@@ -28,7 +42,7 @@ const SearchPage = () => {
     } catch (error) {
       const err = error as ErrorResponseType;
       if (err.response?.status === 404) {
-        renderSnackbar("이 책은 등록되지 않았습니다", "warning");
+        registerBook(user);
         return;
       }
       renderSnackbar(
@@ -46,6 +60,10 @@ const SearchPage = () => {
         page: two,
       },
     });
+  };
+
+  const handleSearchPageModalClose = () => {
+    setIsSearchPageModalOpen(false);
   };
 
   useEffect(() => {
@@ -90,6 +108,10 @@ const SearchPage = () => {
           onChange={handlePaginationChange}
         />
       </S.PaginationWrapper>
+      <SearchPageModal
+        open={isSearchPageModalOpen}
+        onClose={handleSearchPageModalClose}
+      />
     </>
   );
 };

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -3,23 +3,33 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { getNaverBooks, registerBook } from "../../apis";
 import { BookCard } from "../../components";
-import { BookType } from "../../types/bookType";
+import type { NaverBookResponseType } from "../../types/bookType";
 
 const SearchPage = () => {
   const router = useRouter();
-  const { word } = router.query;
 
-  const [bookList, setBookList] = useState<BookType[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [searchedInfo, setSearchedInfo] = useState({} as NaverBookResponseType);
 
   useEffect(() => {
-    if (word)
-      getNaverBooks(word as string).then((response) => {
-        console.log(response);
-        setBookList(response.items);
-      });
-  }, [word]);
+    const { word, page } = router.query;
+    if (!word) return;
 
-  return bookList ? (
+    const searchNaverBook = async () => {
+      setLoading(true);
+      const data = (await getNaverBooks(
+        word as string,
+        (Number(page) - 1) * 10 + 1
+      )) as NaverBookResponseType;
+      setSearchedInfo(data);
+      setLoading(false);
+    };
+    searchNaverBook();
+  }, [router.query]);
+
+  return loading ? (
+    "로딩 중"
+  ) : (
     <Box
       sx={{
         display: "flex",
@@ -27,26 +37,26 @@ const SearchPage = () => {
         flexWrap: "wrap",
       }}
     >
-      {bookList.map((book) => (
-        <BookCard
-          key={book.isbn}
-          src={book.image}
-          title={book.title}
-          size={10}
-          onClick={() => {
-            registerBook(
-              book,
-              process.env.NEXT_PUBLIC_FAKE_TOKEN as string
-            ).then((response) => {
-              console.log(response);
-              router.push(`/book/${response}`);
-            });
-          }}
-        />
-      ))}
+      {searchedInfo.items.length
+        ? searchedInfo.items.map((book) => (
+            <BookCard
+              key={book.isbn}
+              src={book.image}
+              title={book.title}
+              size={10}
+              onClick={() => {
+                registerBook(
+                  book,
+                  process.env.NEXT_PUBLIC_FAKE_TOKEN as string
+                ).then((response) => {
+                  console.log(response);
+                  router.push(`/book/${response}`);
+                });
+              }}
+            />
+          ))
+        : "검색 결과가 없습니다"}
     </Box>
-  ) : (
-    "로딩 중"
   );
 };
 

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -1,18 +1,29 @@
-import { Box } from "@mui/system";
+import { Pagination, Box } from "@mui/material";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import type { ChangeEvent } from "react";
 import { getNaverBooks, registerBook } from "../../apis";
 import { BookCard } from "../../components";
 import type { NaverBookResponseType } from "../../types/bookType";
 
 const SearchPage = () => {
   const router = useRouter();
+  const { word, page } = router.query;
 
   const [loading, setLoading] = useState(true);
   const [searchedInfo, setSearchedInfo] = useState({} as NaverBookResponseType);
 
+  const handlePaginationChange = (_: ChangeEvent<unknown>, two: number) => {
+    router.push({
+      pathname: "/search",
+      query: {
+        word,
+        page: two,
+      },
+    });
+  };
+
   useEffect(() => {
-    const { word, page } = router.query;
     if (!word) return;
 
     const searchNaverBook = async () => {
@@ -30,33 +41,44 @@ const SearchPage = () => {
   return loading ? (
     "로딩 중"
   ) : (
-    <Box
-      sx={{
-        display: "flex",
-        gap: "1rem",
-        flexWrap: "wrap",
-      }}
-    >
-      {searchedInfo.items.length
-        ? searchedInfo.items.map((book) => (
-            <BookCard
-              key={book.isbn}
-              src={book.image}
-              title={book.title}
-              size={10}
-              onClick={() => {
-                registerBook(
-                  book,
-                  process.env.NEXT_PUBLIC_FAKE_TOKEN as string
-                ).then((response) => {
-                  console.log(response);
-                  router.push(`/book/${response}`);
-                });
-              }}
-            />
-          ))
-        : "검색 결과가 없습니다"}
-    </Box>
+    <>
+      <Box
+        sx={{
+          display: "flex",
+          gap: "1rem",
+          flexWrap: "wrap",
+          marginBottom: "2rem",
+        }}
+      >
+        {searchedInfo.items.length
+          ? searchedInfo.items.map((book) => (
+              <BookCard
+                key={book.isbn}
+                src={book.image}
+                title={book.title}
+                size={10}
+                onClick={() => {
+                  registerBook(
+                    book,
+                    process.env.NEXT_PUBLIC_FAKE_TOKEN as string
+                  ).then((response) => {
+                    console.log(response);
+                    router.push(`/book/${response}`);
+                  });
+                }}
+              />
+            ))
+          : "검색 결과가 없습니다"}
+      </Box>
+      <Pagination
+        count={Math.ceil(searchedInfo.total / 10)}
+        variant="outlined"
+        shape="rounded"
+        color="primary"
+        page={Number(router.query?.page)}
+        onChange={handlePaginationChange}
+      />
+    </>
   );
 };
 

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -1,4 +1,4 @@
-import { Pagination, Box } from "@mui/material";
+import { Pagination } from "@mui/material";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import type { ChangeEvent } from "react";
@@ -6,6 +6,8 @@ import { getNaverBooks, registerBook } from "../../apis";
 import { BookCard } from "../../components";
 import type { NaverBookResponseType } from "../../types/bookType";
 import * as S from "../../styles/SearchPageStyle";
+
+const SEARCH_URL = "/search";
 
 const SearchPage = () => {
   const router = useRouter();
@@ -16,7 +18,7 @@ const SearchPage = () => {
 
   const handlePaginationChange = (_: ChangeEvent<unknown>, two: number) => {
     router.push({
-      pathname: "/search",
+      pathname: SEARCH_URL,
       query: {
         word,
         page: two,

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -5,6 +5,7 @@ import type { ChangeEvent } from "react";
 import { getNaverBooks, registerBook } from "../../apis";
 import { BookCard } from "../../components";
 import type { NaverBookResponseType } from "../../types/bookType";
+import * as S from "../../styles/SearchPageStyle";
 
 const SearchPage = () => {
   const router = useRouter();
@@ -42,14 +43,7 @@ const SearchPage = () => {
     "로딩 중"
   ) : (
     <>
-      <Box
-        sx={{
-          display: "flex",
-          gap: "1rem",
-          flexWrap: "wrap",
-          marginBottom: "2rem",
-        }}
-      >
+      <S.BookCardContainer>
         {searchedInfo.items.length
           ? searchedInfo.items.map((book) => (
               <BookCard
@@ -69,15 +63,17 @@ const SearchPage = () => {
               />
             ))
           : "검색 결과가 없습니다"}
-      </Box>
-      <Pagination
-        count={Math.ceil(searchedInfo.total / 10)}
-        variant="outlined"
-        shape="rounded"
-        color="primary"
-        page={Number(router.query?.page)}
-        onChange={handlePaginationChange}
-      />
+      </S.BookCardContainer>
+      <S.PaginationWrapper>
+        <Pagination
+          count={Math.ceil(searchedInfo.total / 10)}
+          variant="outlined"
+          shape="rounded"
+          color="primary"
+          page={Number(router.query?.page)}
+          onChange={handlePaginationChange}
+        />
+      </S.PaginationWrapper>
     </>
   );
 };

--- a/styles/SearchPageStyle.ts
+++ b/styles/SearchPageStyle.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+
+export const BookCardContainer = styled("div")`
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  margin-bottom: 2rem;
+  justify-items: center;
+`;
+
+export const PaginationWrapper = styled("div")`
+  display: flex;
+  justify-content: center;
+`;

--- a/types/bookType.ts
+++ b/types/bookType.ts
@@ -12,3 +12,11 @@ export interface BookType extends NaverBookType {
   id: number;
   createdAt: string;
 }
+
+export interface NaverBookResponseType {
+  display: number;
+  items: NaverBookType[];
+  lastBuildDate: string;
+  start: number;
+  total: number;
+}

--- a/types/errorTypes.ts
+++ b/types/errorTypes.ts
@@ -1,0 +1,11 @@
+import type { AxiosError } from "axios";
+
+interface ErrorType {
+  message: string;
+}
+
+interface ErrorDataType {
+  errors: ErrorType[];
+}
+
+export type ErrorResponseType = AxiosError<ErrorDataType>;


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

검색 페이지에서 검색된 책을 클릭했을 때 로직을 바뀐 기획대로 수정했습니다
책 클릭 => 책모이 DB에 등록된 책인지 확인

1. 등록된 책이면 그 책 상세 페이지로 이동
원래 되는 기능이라 캡처 안했습니다
2. 등록되지 않은 책일 때
   1. 비로그인이면 `이 책은 등록되지 않았다. 책 등록해줘라. 근데 로그인해야된다`를 모달로 알려주어서 로그인을 유도합니다
![비로그인 클릭](https://user-images.githubusercontent.com/50919342/183807232-6be896e0-512a-4973-87b7-73dbd083861f.gif)
   2. 이미 로그인이면 책 등록 요청을 보내고 응답받은 bookId로 페이지를 이동합니다
![로그인 클릭](https://user-images.githubusercontent.com/50919342/183807293-8bc1d896-2466-4ba9-9d5d-b0665d01b52a.gif)

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

- 바뀐 기획 (위 설명 참고)대로 검색 페이지에서 북카드를 클릭했을 때 로직을 변경했습니다
- pagination을 누락해서 다시 추가했습니다
- 검색시에는 무조건 해당 검색어의 1페이지로 이동합니다 `?word=검색값&page=1`
- 페이지 이동시에는 page만 1개 늘립니다 `?word=검색값?page=클릭한페이지`
  - 네이버 api 요청시에는 (page - 1) * 10 + 1부터 요청합니다 (1페이지면 1, 2페이지면 11, 3페이지면 21...)
- catch (error) 관련 데이터를 사용하게 되어서 `types/errorTypes.tsx`에 백엔드가 내려주기로 한 에러 응답 타입을 정의했습니다
저런식으로 사용하면 vscode에서 자동완성도 되더라고요
![에러타입](https://user-images.githubusercontent.com/50919342/183808335-a00cda83-1d94-4d8e-af99-133eee94d760.gif)

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

- 사용자에게 내용을 전달해주고 확인을 받으려고 하다보니 모달이 점점 많아지는것같습니다. 다른 방법을 써볼까요?

### 🚀 연관된 이슈
close issue #71 