### PR TITLE
refactor: 메인 페이지 북 카드 한 줄 ellipsis 처리

### DIFF
--- a/components/BookCard/style.tsx
+++ b/components/BookCard/style.tsx
@@ -24,7 +24,7 @@ export const ImageWrapper = styled.div<BookCardProps>`
 `;
 
 export const BookTitle = styled.p`
-  margin: 0;
+  margin-top: 1rem;
   padding: 0;
   text-align: center;
 `;

--- a/components/BookCard/style.tsx
+++ b/components/BookCard/style.tsx
@@ -27,4 +27,7 @@ export const BookTitle = styled.p`
   margin-top: 1rem;
   padding: 0;
   text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -26,12 +26,14 @@ const Home = ({ books }: ServerSidePropsType) => {
       <S.StyledUl>
         {latestBooks.map((book) => (
           <S.StyledList key={book.id}>
-            <BookCard
-              src={book.image}
-              title=""
-              size={10}
-              onClick={() => handleBookCardClick(book.id)}
-            />
+            <S.BookCardWrapper>
+              <BookCard
+                src={book.image}
+                title={book.title}
+                size={10}
+                onClick={() => handleBookCardClick(book.id)}
+              />
+            </S.BookCardWrapper>
           </S.StyledList>
         ))}
       </S.StyledUl>
@@ -40,12 +42,14 @@ const Home = ({ books }: ServerSidePropsType) => {
       <S.StyledUl>
         {studyLatestBooks.map((book) => (
           <S.StyledList key={book.id}>
-            <BookCard
-              src={book.image}
-              title=""
-              size={10}
-              onClick={() => handleBookCardClick(book.id)}
-            />
+            <S.BookCardWrapper>
+              <BookCard
+                src={book.image}
+                title={book.title}
+                size={10}
+                onClick={() => handleBookCardClick(book.id)}
+              />
+            </S.BookCardWrapper>
           </S.StyledList>
         ))}
       </S.StyledUl>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -26,14 +26,12 @@ const Home = ({ books }: ServerSidePropsType) => {
       <S.StyledUl>
         {latestBooks.map((book) => (
           <S.StyledList key={book.id}>
-            <S.BookCardWrapper>
-              <BookCard
-                src={book.image}
-                title={book.title}
-                size={10}
-                onClick={() => handleBookCardClick(book.id)}
-              />
-            </S.BookCardWrapper>
+            <BookCard
+              src={book.image}
+              title={book.title}
+              size={10}
+              onClick={() => handleBookCardClick(book.id)}
+            />
           </S.StyledList>
         ))}
       </S.StyledUl>
@@ -42,14 +40,12 @@ const Home = ({ books }: ServerSidePropsType) => {
       <S.StyledUl>
         {studyLatestBooks.map((book) => (
           <S.StyledList key={book.id}>
-            <S.BookCardWrapper>
-              <BookCard
-                src={book.image}
-                title={book.title}
-                size={10}
-                onClick={() => handleBookCardClick(book.id)}
-              />
-            </S.BookCardWrapper>
+            <BookCard
+              src={book.image}
+              title={book.title}
+              size={10}
+              onClick={() => handleBookCardClick(book.id)}
+            />
           </S.StyledList>
         ))}
       </S.StyledUl>

--- a/styles/MainPageStyle.tsx
+++ b/styles/MainPageStyle.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
+import { BookCard } from "../components";
 
-export const MainPageWrapper = styled("div")`
+export const MainPageWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -9,7 +10,7 @@ export const MainPageWrapper = styled("div")`
   }
 `;
 
-export const StyledUl = styled("ul")`
+export const StyledUl = styled.ul`
   list-style: none;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr;
@@ -22,14 +23,33 @@ export const StyledUl = styled("ul")`
   }
 `;
 
-export const StyledList = styled("li")`
+export const StyledList = styled.li`
   justify-self: center;
   &:hover {
     transform: scale(1.05) translateY(-10px);
   }
 `;
 
-export const StyledSpan = styled("span")`
+export const StyledSpan = styled.span`
   font-size: 1.5rem;
   font-weight: bold;
+`;
+
+export const BookCardWrapper = styled.div`
+  & p {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`;
+
+interface BookCardProps {
+  src: string;
+  title: string;
+  size: number;
+  onClick: () => void;
+}
+
+export const BookCardTest = styled(BookCard)<BookCardProps>`
+  border: 1px solid red;
 `;

--- a/styles/MainPageStyle.tsx
+++ b/styles/MainPageStyle.tsx
@@ -35,14 +35,6 @@ export const StyledSpan = styled.span`
   font-weight: bold;
 `;
 
-export const BookCardWrapper = styled.div`
-  & p {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-`;
-
 interface BookCardProps {
   src: string;
   title: string;


### PR DESCRIPTION
기타 스타일 수정

### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
<img width="1177" alt="image" src="https://user-images.githubusercontent.com/32607413/183898964-a08b85a4-8eeb-434d-98e5-394fe319a170.png">

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

BookCard 컴포넌트를 감싸는 Warpper 객체를 하나 만들어서 ellipsis 처리를 했습니다.


### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

북 카드 컴포넌트에서 이미지와 타이틀 사이에 1rem 간격을 추가 했습니다.
검색 페이지에서 타이틀을 줄이지 않고 모두 보여주고 있는데  메인 페이지에서는 줄이고 있는게
이상할 수도 있다고 생각됩니다. 그럴 경우 줄이지 않고 그냥 다 보여주는 방향으로 가야 할 것 같은데
어떠신가요??

### 🚀 연관된 이슈

close #106 


### 변경 사항

메인 페이지, 검색 페이지 모두 ellipsis 처리되도록 BookCard 컴포넌트를 수정했습니다.