### PR TITLE
#103/feat/study detail tab

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
     curly: ["error", "multi"],
     "import/no-extraneous-dependencies": "off",
     "react/react-in-jsx-scope": "off",
+    "react/jsx-no-useless-fragment": "off",
   },
   settings: {
     "import/resolver": {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
     curly: ["error", "multi"],
     "import/no-extraneous-dependencies": "off",
     "react/react-in-jsx-scope": "off",
-    "react/jsx-no-useless-fragment": "off",
   },
   settings: {
     "import/resolver": {

--- a/components/NoAccess/NoAccess.stories.tsx
+++ b/components/NoAccess/NoAccess.stories.tsx
@@ -1,0 +1,14 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { NoAccess } from ".";
+
+export default {
+  title: "Components/NoAccess",
+  component: NoAccess,
+} as ComponentMeta<typeof NoAccess>;
+
+const Template: ComponentStory<typeof NoAccess> = (args) => (
+  <NoAccess {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/components/NoAccess/NoAccess.tsx
+++ b/components/NoAccess/NoAccess.tsx
@@ -8,9 +8,9 @@ interface NoAccessProps {
 
 export const NoAccess = ({ title, description }: NoAccessProps) => {
   return (
-    <S.styledDiv>
+    <S.StyledDiv>
       <Typography variant="h5">{title}</Typography>
       <Typography variant="h6">{description}</Typography>
-    </S.styledDiv>
+    </S.StyledDiv>
   );
 };

--- a/components/NoAccess/NoAccess.tsx
+++ b/components/NoAccess/NoAccess.tsx
@@ -1,0 +1,16 @@
+import { Typography } from "@mui/material";
+import * as S from "./style";
+
+interface NoAccessProps {
+  title: string;
+  description: string;
+}
+
+export const NoAccess = ({ title, description }: NoAccessProps) => {
+  return (
+    <S.styledDiv>
+      <Typography variant="h5">{title}</Typography>
+      <Typography variant="h6">{description}</Typography>
+    </S.styledDiv>
+  );
+};

--- a/components/NoAccess/index.ts
+++ b/components/NoAccess/index.ts
@@ -1,0 +1,1 @@
+export { NoAccess } from "./NoAccess";

--- a/components/NoAccess/style.tsx
+++ b/components/NoAccess/style.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-export const styledDiv = styled.div`
+export const StyledDiv = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/components/NoAccess/style.tsx
+++ b/components/NoAccess/style.tsx
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+
+export const styledDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+`;

--- a/features/ApplicantList/ApplicantList.stories.tsx
+++ b/features/ApplicantList/ApplicantList.stories.tsx
@@ -1,0 +1,14 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { ApplicantList } from ".";
+
+export default {
+  title: "Components/ApplicantList",
+  component: ApplicantList,
+} as ComponentMeta<typeof ApplicantList>;
+
+const Template: ComponentStory<typeof ApplicantList> = (args) => (
+  <ApplicantList />
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/features/ApplicantList/ApplicantList.tsx
+++ b/features/ApplicantList/ApplicantList.tsx
@@ -1,25 +1,11 @@
-import { Box, Button, Modal, Typography } from "@mui/material";
+import { Button, Modal, Typography } from "@mui/material";
 import { useState } from "react";
 import * as S from "./style";
-
-const style = {
-  position: "absolute" as "absolute",
-  top: "50%",
-  left: "50%",
-  transform: "translate(-50%, -50%)",
-  width: 400,
-  bgcolor: "background.paper",
-  border: "2px solid #000",
-  boxShadow: 24,
-  p: 4,
-};
 
 export const ApplicantList = () => {
   const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
-
-  console.log("Modal open");
 
   return (
     <>
@@ -31,9 +17,9 @@ export const ApplicantList = () => {
         onClose={handleClose}
         aria-labelledby="modal-modal-title"
         aria-describedby="modal-modal-description"
-        className="sdsa"
       >
         <S.StyledModal>
+          {/* TODO 신청자 목록 가져오기 */}
           <Typography id="modal-modal-title" variant="h6" component="h2">
             Text in a modal
           </Typography>

--- a/features/ApplicantList/ApplicantList.tsx
+++ b/features/ApplicantList/ApplicantList.tsx
@@ -1,0 +1,50 @@
+import { Box, Button, Modal, Typography } from "@mui/material";
+import { useState } from "react";
+import * as S from "./style";
+
+const style = {
+  position: "absolute" as "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: 400,
+  bgcolor: "background.paper",
+  border: "2px solid #000",
+  boxShadow: 24,
+  p: 4,
+};
+
+export const ApplicantList = () => {
+  const [open, setOpen] = useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  console.log("Modal open");
+
+  return (
+    <>
+      <Button variant="contained" onClick={handleOpen}>
+        신청자 목록 보기
+      </Button>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+        className="sdsa"
+      >
+        <S.StyledModal>
+          <Typography id="modal-modal-title" variant="h6" component="h2">
+            Text in a modal
+          </Typography>
+          <Typography id="modal-modal-description" sx={{ mt: 2 }}>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Nihil
+            aperiam, voluptates deleniti exercitationem impedit eligendi
+            obcaecati, harum repellendus aspernatur repellat aliquid alias
+            dolorum? Ipsa, fuga dignissimos ratione nam veritatis quam?
+          </Typography>
+        </S.StyledModal>
+      </Modal>
+    </>
+  );
+};

--- a/features/ApplicantList/index.ts
+++ b/features/ApplicantList/index.ts
@@ -1,0 +1,1 @@
+export {ApplicantList} from "./ApplicantList"

--- a/features/ApplicantList/style.tsx
+++ b/features/ApplicantList/style.tsx
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+
+export const StyledModal = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 400px;
+  background-color: white;
+  border: 2px solid black;
+  box-shadow: 24;
+  padding: 1rem;
+`;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,11 +24,11 @@ const Home = ({ books }: ServerSidePropsType) => {
     <S.MainPageWrapper>
       <S.StyledSpan>가장 최근 추가된 책</S.StyledSpan>
       <S.StyledUl>
-        {latestBooks?.map((book) => (
+        {latestBooks.map((book) => (
           <S.StyledList key={book.id}>
             <BookCard
               src={book.image}
-              title=""
+              title={book.title}
               size={10}
               onClick={() => handleBookCardClick(book.id)}
             />
@@ -38,11 +38,11 @@ const Home = ({ books }: ServerSidePropsType) => {
 
       <S.StyledSpan>가장 최근 스터디가 만들어진 책</S.StyledSpan>
       <S.StyledUl>
-        {studyLatestBooks?.map((book) => (
+        {studyLatestBooks.map((book) => (
           <S.StyledList key={book.id}>
             <BookCard
               src={book.image}
-              title=""
+              title={book.title}
               size={10}
               onClick={() => handleBookCardClick(book.id)}
             />

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -63,83 +63,72 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
     // TODO: 수정 페이지
   };
 
-  return (
+  return user && isStudyMember ? (
     <>
-      {user && isStudyMember ? (
-        <>
-          <StudyDetailCard study={study} members={members} />
-          <S.TabsContainer>
-            <Tabs value={tabNumber} onChange={handleTabChange}>
-              <Tab label="공지" />
-              <Tab label="자유" />
-            </Tabs>
-            <S.ButtonsWrapper>
-              {isOwner && (
-                <>
-                  <ApplicantList />
-                  <Button
-                    variant="contained"
-                    onClick={handleStudyEditButtonClick}
-                  >
-                    스터디 정보 수정
-                  </Button>
-                </>
-              )}
-              {tabNumber === NOTICE_BOARD_TAB && !isOwner ? (
-                ""
-              ) : (
-                <Button variant="contained" onClick={handleWriteButtonClick}>
-                  글 작성
-                </Button>
-              )}
-            </S.ButtonsWrapper>
-          </S.TabsContainer>
-
-          <TabPanel value={tabNumber} index={NOTICE_BOARD_TAB}>
-            <S.StyledUl>
-              {DummyPost.map((post) => (
-                <S.StyledList
-                  key={post.id}
-                  onClick={() => {
-                    handlePostClick(+post.id);
-                  }}
-                >
-                  <PostCard post={post} />
-                </S.StyledList>
-              ))}
-            </S.StyledUl>
-          </TabPanel>
-          <TabPanel value={tabNumber} index={FREE_BOARD_TAB}>
-            <S.StyledUl>
-              {DummyPost.map((post) => (
-                <S.StyledList
-                  key={post.id}
-                  onClick={() => {
-                    handlePostClick(+post.id);
-                  }}
-                >
-                  <PostCard post={post} />
-                </S.StyledList>
-              ))}
-            </S.StyledUl>
-          </TabPanel>
-        </>
-      ) : (
-        <>
-          {user ? (
-            <NoAccess
-              title="이 페이지는 스터디에 참여한 사용자만 이용할 수 있습니다."
-              description="스터디에 참가 신청을 하시기 바랍니다."
-            />
-          ) : (
-            <NoAccess
-              title="이 페이지는 로그인한 사용자만 이용할 수 있습니다."
-              description="책모이에 로그인하시면 다양한 서비스를 이용하실 수 있습니다."
-            />
+      <StudyDetailCard study={study} members={members} />
+      <S.TabsContainer>
+        <Tabs value={tabNumber} onChange={handleTabChange}>
+          <Tab label="공지" />
+          <Tab label="자유" />
+        </Tabs>
+        <S.ButtonsWrapper>
+          {isOwner && (
+            <>
+              <ApplicantList />
+              <Button variant="contained" onClick={handleStudyEditButtonClick}>
+                스터디 정보 수정
+              </Button>
+            </>
           )}
-        </>
-      )}
+          {tabNumber === NOTICE_BOARD_TAB && !isOwner ? (
+            ""
+          ) : (
+            <Button variant="contained" onClick={handleWriteButtonClick}>
+              글 작성
+            </Button>
+          )}
+        </S.ButtonsWrapper>
+      </S.TabsContainer>
+
+      <TabPanel value={tabNumber} index={NOTICE_BOARD_TAB}>
+        <S.StyledUl>
+          {DummyPost.map((post) => (
+            <S.StyledList
+              key={post.id}
+              onClick={() => {
+                handlePostClick(+post.id);
+              }}
+            >
+              <PostCard post={post} />
+            </S.StyledList>
+          ))}
+        </S.StyledUl>
+      </TabPanel>
+      <TabPanel value={tabNumber} index={FREE_BOARD_TAB}>
+        <S.StyledUl>
+          {DummyPost.map((post) => (
+            <S.StyledList
+              key={post.id}
+              onClick={() => {
+                handlePostClick(+post.id);
+              }}
+            >
+              <PostCard post={post} />
+            </S.StyledList>
+          ))}
+        </S.StyledUl>
+      </TabPanel>
     </>
+  ) : user ? (
+    <NoAccess
+      title="이 페이지는 스터디에 참여한 사용자만 이용할 수 있습니다."
+      description="스터디에 참가 신청을 하시기 바랍니다."
+    />
+  ) : (
+    <NoAccess
+      title="이 페이지는 로그인한 사용자만 이용할 수 있습니다."
+      description="책모이에 로그인하시면 다양한 서비스를 이용하실 수 있습니다."
+    />
   );
 };
 

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -11,6 +11,7 @@ import { PostCard } from "../../components/PostCard";
 import { DummyPost } from "../../commons/dummyPost";
 import { useUserContext } from "../../hooks/useUserContext";
 import * as S from "../../styles/StudyDetailPageStyle";
+import { ApplicantList } from "../../features/ApplicantList";
 
 interface ServerSidePropType {
   studyData: StudyDetailType;
@@ -22,6 +23,8 @@ interface ServerSidePropType {
 // TODO User가 스터디장일 경우와 아닐 경우 탭, 버튼 권한 부여
 
 const STUDY_OWNER = 0;
+const NOTICE_BOARD_TAB = 0;
+const FREE_BOARD_TAB = 1;
 
 const writeButton = (
   tabNumber: number,
@@ -74,26 +77,42 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
     });
   };
 
-  const handleButtonClick = () => {
-    router.push({
-      pathname: `/postCreate`,
-      query: { tabNumber },
-    });
+  const handleWriteButtonClick = () => {
+    router.push(`/postCreate`, { query: { tabNumber } });
+  };
+
+  const handleStudyEditButtonClick = () => {
+    // TODO: 수정 페이지
   };
 
   return (
     <>
       <StudyDetailCard study={study} members={members} />
-      <S.TabsWrapper>
+      <S.TabsContainer>
         <Tabs value={tabNumber} onChange={handleTabChange}>
           <Tab label="공지" />
           <Tab label="자유" />
-          {isOwner && <Tab label="관리자" />}
         </Tabs>
-        {writeButton(tabNumber, isOwner, handleButtonClick)}
-      </S.TabsWrapper>
-      {/* TODO 더미 데이터 사용중 교체 예정 */}
-      <TabPanel value={tabNumber} index={0}>
+        <S.ButtonsWrapper>
+          {isOwner && (
+            <>
+              <ApplicantList />
+              <Button variant="contained" onClick={handleStudyEditButtonClick}>
+                스터디 정보 수정
+              </Button>
+            </>
+          )}
+          {tabNumber === NOTICE_BOARD_TAB && !isOwner ? (
+            ""
+          ) : (
+            <Button variant="contained" onClick={handleWriteButtonClick}>
+              글 작성
+            </Button>
+          )}
+        </S.ButtonsWrapper>
+      </S.TabsContainer>
+
+      <TabPanel value={tabNumber} index={NOTICE_BOARD_TAB}>
         <S.StyledUl>
           {DummyPost.map((post) => (
             <S.StyledList
@@ -107,21 +126,7 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
           ))}
         </S.StyledUl>
       </TabPanel>
-      <TabPanel value={tabNumber} index={1}>
-        <S.StyledUl>
-          {DummyPost.map((post) => (
-            <S.StyledList
-              key={post.id}
-              onClick={() => {
-                handlePostClick(+post.id);
-              }}
-            >
-              <PostCard post={post} />
-            </S.StyledList>
-          ))}
-        </S.StyledUl>
-      </TabPanel>
-      <TabPanel value={tabNumber} index={2}>
+      <TabPanel value={tabNumber} index={FREE_BOARD_TAB}>
         <S.StyledUl>
           {DummyPost.map((post) => (
             <S.StyledList

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -18,9 +18,6 @@ interface ServerSidePropType {
   studyData: StudyDetailType;
 }
 
-// TODO 비 로그인 접근 막기!
-// TODO 로그인 상태일 때, 스터디원이 아닐 경우 접근 막기!
-
 const STUDY_OWNER = 0;
 const NOTICE_BOARD_TAB = 0;
 const FREE_BOARD_TAB = 1;
@@ -46,8 +43,6 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
   }, [user]);
 
   const isStudyMember = membersIdList.includes(user?.id as string);
-
-  // console.log("include?", members.includes(user?.id));
 
   const handleTabChange = (e: SyntheticEvent, newValue: number) => {
     setTabNumber(newValue);

--- a/styles/StudyDetailPageStyle.tsx
+++ b/styles/StudyDetailPageStyle.tsx
@@ -1,9 +1,14 @@
 import styled from "@emotion/styled";
 
-export const TabsWrapper = styled.div`
+export const TabsContainer = styled.div`
   display: flex;
   justify-content: space-between;
   margin: 1rem;
+`;
+
+export const ButtonsWrapper = styled.div`
+  display: flex;
+  gap: 1rem;
 `;
 
 export const StyledUl = styled.ul`


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
![Kapture 2022-08-11 at 02 12 06](https://user-images.githubusercontent.com/32607413/183975161-73ef84f5-8e70-47f4-af99-f99085d409bf.gif)

[로그아웃 상태]
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/32607413/183975885-c61d2d29-9923-4968-9283-3af48593d76d.png">

[로그인 상태이지만 스터디 가입은 하지 않은 상태]
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/32607413/183975988-7e372404-7ba1-4359-9b25-6a510c001d19.png">


### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

- 공지, 자유 탭만 존재하며 현재 스터디장으로 접근한 상태입니다. 스터디 신청 목록 모달은 아직 API가
완성되지 않은 관계로 새로 이슈 만들어서 만들겠습니다.

- 게시글 작성 페이지로 이동 가능합니다. 

- 게시글 상세 페이지도 더미로 이동 가능합니다. 마찬가지로 API가 완료되는 대로 만들겠습니다.

- 스터디 상세 페이지에 접근 할 때, 로그인 상태를 먼저 판별하고 로그인을 유도합니다.

- 로그인한 상태이지만 스터디원이 아닐 경우 접근이 불가하고 스터디 참여를 유도합니다.

- 접근 제한을 위해서 NoAccess 컴포넌트를 만들었습니다.

- title, description을 전달해서 내용을 표기할 수 있습니다.


### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

로그인 상태, 스터디 참가 여부 등을 판별하기 위해 코드를 작성하다보니 너무 길고 더러워진 느낌입니다..
클린 코드 방법이 있다면 알려주세요...

NoAccess 컴포넌트 이름은 너무 막지은 느낌인데 좋은 이름이 있다면 추천해주세요. 재사용성이 없을까요? 없다면 그냥 제 페이지에 따로 만들겠습니다...

eslint 관련해서 추가한 내용이 있습니다.
`"react/jsx-no-useless-fragment": "off",`
```tsx
return (
    <>
      {user && isStudyMember ? (
        <>
          <StudyDetailCard study={study} members={members} />
          <S.TabsContainer>
            <Tabs value={tabNumber} onChange={handleTabChange}>
              <Tab label="공지" />
              <Tab label="자유" />
            </Tabs>
            <S.ButtonsWrapper>
              {isOwner && (
```
JSX 내부에서 로그인 상태와 스터디 참가자 상태를 확인하기 위한 표현식을 작성할 때 에러가 발생하길래
끄는 방향으로 설정 했습니다. 다른분들은 괜찮으신가요... 괜찮다면 저는 끄고 싶습니다..


### 🚀 연관된 이슈

close #103 