### PR TITLE
#117/feat/Post Detail Add Input

### DIFF
--- a/pages/post/[id].tsx
+++ b/pages/post/[id].tsx
@@ -1,12 +1,11 @@
 import { SyntheticEvent, useState } from "react";
 import { useRouter } from "next/router";
-import { Divider, Tabs, Tab } from "@mui/material";
+import { Divider, Tabs, Tab, Button } from "@mui/material";
 import * as S from "../../styles/PostStyle";
 import { CommentInput } from "../../components/CommentInput";
 
 // TODO api가 완성되면 Type과 api 작업 필요
 const PostPage = () => {
-  // TODO StudyDetail 페이지에서 value 쿼리 전달받아서 저장해야함
   const router = useRouter();
 
   const { studyId, tabNumber } = router.query;
@@ -25,12 +24,20 @@ const PostPage = () => {
     setValue(newValue);
   };
 
+  // TODO 현재 로그인한 유저와 게시글을 작성한 유저를 비교해서 동일할 경우 삭제, 수정 버튼 보이기
+
   return (
     <>
-      <Tabs value={value} onChange={handleTabChange}>
-        <Tab label="공지" />
-        <Tab label="자유" />
-      </Tabs>
+      <S.TabsContainer>
+        <Tabs value={value} onChange={handleTabChange}>
+          <Tab label="공지" />
+          <Tab label="자유" />
+        </Tabs>
+        <S.ButtonsContainer>
+          <Button variant="contained">수정</Button>
+          <Button variant="contained">삭제</Button>
+        </S.ButtonsContainer>
+      </S.TabsContainer>
       <S.BoardTitle>Legal Abortion Is Not a Polarizing Issue</S.BoardTitle>
       <S.BoardInfo>
         <S.StyledAvatar src="https://i.picsum.photos/id/962/200/300.jpg?hmac=wvuv8EVOoNE5J3sBkBx-1wcVHNbgJ_Z1dS98YhnShjM" />

--- a/pages/post/[id].tsx
+++ b/pages/post/[id].tsx
@@ -1,26 +1,35 @@
-import { useState } from "react";
+import { SyntheticEvent, useState } from "react";
 import { useRouter } from "next/router";
 import { Divider, Tabs, Tab } from "@mui/material";
 import * as S from "../../styles/PostStyle";
+import { CommentInput } from "../../components/CommentInput";
 
 // TODO api가 완성되면 Type과 api 작업 필요
 const PostPage = () => {
   // TODO StudyDetail 페이지에서 value 쿼리 전달받아서 저장해야함
-  const [value, setValue] = useState(0);
   const router = useRouter();
+
+  const { studyId, tabNumber } = router.query;
+  const currentTab = tabNumber ? +tabNumber : 0;
+  const [value, setValue] = useState(currentTab);
+
   // TODO api 연결 후 지울 변수
   const DATE = "2022/08/05";
   const [year, month, day] = DATE.split("/");
 
-  const handleClickTab = () => {
-    router.push({ pathname: "/studyDetail", query: { value } });
+  const handleTabChange = (e: SyntheticEvent, newValue: number) => {
+    router.push({
+      pathname: `/study/${studyId}`,
+      query: { tabNumber: newValue },
+    });
+    setValue(newValue);
   };
+
   return (
     <>
-      <Tabs value={value}>
-        <Tab label="공지" onClick={handleClickTab} />
-        <Tab label="자유" onClick={handleClickTab} />
-        <Tab label="관리자" disabled onClick={handleClickTab} />
+      <Tabs value={value} onChange={handleTabChange}>
+        <Tab label="공지" />
+        <Tab label="자유" />
       </Tabs>
       <S.BoardTitle>Legal Abortion Is Not a Polarizing Issue</S.BoardTitle>
       <S.BoardInfo>
@@ -130,6 +139,8 @@ const PostPage = () => {
         weeks.
       </S.BoardContent>
       <Divider />
+      <CommentInput />
+      {/* TODO Comment List 출력 */}
     </>
   );
 };

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -50,7 +50,8 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
   const { study, members } = studyData;
 
   const router = useRouter();
-  const { value: tabValue } = router.query;
+  const { id: studyId, tabNumber: tabValue } = router.query;
+  console.log("query", router.query);
   const currentTab = tabValue ? parseInt(tabValue as string, 10) : 0;
   const [tabNumber, setTabNumber] = useState(currentTab);
 
@@ -70,7 +71,7 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
   const handlePostClick = (id: number) => {
     router.push({
       pathname: `/post/${id}`,
-      query: { tabNumber },
+      query: { tabNumber, studyId },
     });
   };
 

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -51,7 +51,6 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
 
   const router = useRouter();
   const { id: studyId, tabNumber: tabValue } = router.query;
-  console.log("query", router.query);
   const currentTab = tabValue ? parseInt(tabValue as string, 10) : 0;
   const [tabNumber, setTabNumber] = useState(currentTab);
 

--- a/styles/PostStyle.tsx
+++ b/styles/PostStyle.tsx
@@ -1,6 +1,17 @@
 import styled from "@emotion/styled";
 import { Avatar } from "@mui/material";
 
+export const TabsContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const ButtonsContainer = styled.div`
+  display: flex;
+  height: 2rem;
+  gap: 1rem;
+`;
+
 export const BoardTitle = styled.div`
   margin: 1rem 0;
   font-size: 2rem;


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/32607413/184074421-42eaf6c9-64b4-4734-92a0-3f2844bd465c.png">
게시글 상세 페이지에서 수정, 삭제 버튼을 만들고 작성 input을 추가 했습니다.

추가적으로 게시글 상세 페이지에서 상세 페이지로 이동 기능을 추가했습니다.
![Kapture 2022-08-11 at 15 16 08](https://user-images.githubusercontent.com/32607413/184074644-9c48e806-fd1c-453d-bec6-789405dad3ce.gif)

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

수정 버튼을 클릭하면 수정 페이지로 이동하고 삭제 버튼을 클릭하면 게시글 삭제하는 기능은 
아직 구현되어 있지 않습니다. 머지 후 바로 작업 시작하겠습니다.

스터디 상세 페이지에서 게시글 상세 페이지로 이동할 때 studyID, tabNumber를 주고 받으면서
이동하고 있습니다. 따라서 게시글 상세 페이지에서 탭을 사용해서 스터디 상세페이지의 원하는
탭으로 이동할 수 있습니다.

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

게시글 또한 접속한 유저인지 스터디원인지 확인하는 방어처리가 필요해 보입니다.

게시글이 지금 더미 데이터라 API를 사용한 다음 추가하겠습니다.

이번 PR까지 머지하고 나면 API 작업이 가능할 것 같습니다. 게시글 목록도 불러와지는거 같아요
특이사항 없다면 빠른 머지 후에 추가하겠습니다.


### 🚀 연관된 이슈

close #117 