### PR TITLE
#114/feat/Post 수정 생성 페이지와 기능 구현

### DIFF
--- a/apis/index.ts
+++ b/apis/index.ts
@@ -17,3 +17,5 @@ export { getBooksList, getBookInfo, registerBook } from "./book";
 export { postImage } from "./image";
 
 export { getUser, putUser } from "./user";
+
+export { getPost, createPost, putPost } from "./post";

--- a/apis/index.ts
+++ b/apis/index.ts
@@ -7,6 +7,7 @@ export const END_POINT = {
   getMyInfo: "/me",
   logout: "/logout",
   isbnBook: "/books/isbn",
+  posts: "/posts",
 };
 
 export { getNaverBooks } from "./naver";

--- a/apis/post.ts
+++ b/apis/post.ts
@@ -52,6 +52,6 @@ export const putPost = async (postId: number, post: CreatePostType) => {
       Authorization: `Bearer ${token}`,
     },
   });
-  console.log(data, "포스트 수정");
+  console.log(postId, "포스트 수정");
   return data;
 };

--- a/apis/post.ts
+++ b/apis/post.ts
@@ -1,0 +1,20 @@
+import { apiClient } from "./api";
+import { END_POINT } from ".";
+
+export const getPost = async (postId: string, token: string) => {
+  const data = await apiClient.get(`${END_POINT.posts}/${postId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return data;
+};
+
+export const putPost = async(postId: string, token: string) => {
+  const data = await apiClient.put(`${END_POINT.posts}/${postId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return data;
+};

--- a/apis/post.ts
+++ b/apis/post.ts
@@ -1,20 +1,57 @@
 import { apiClient } from "./api";
 import { END_POINT } from ".";
 
-export const getPost = async (postId: string, token: string) => {
-  const data = await apiClient.get(`${END_POINT.posts}/${postId}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+const token =
+  typeof document !== "undefined" ? document.cookie.split("=")[1] : "";
+
+interface PostType {
+  id: number;
+  title: string;
+  content: string;
+  category: string;
+  studyId: number;
+  writer: string;
+  writerImage: string;
+  commentCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const getPost = async (postId: string) => {
+  const data = await apiClient.get<PostType, PostType>(
+    `${END_POINT.posts}/${postId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
   return data;
 };
 
-export const putPost = async(postId: string, token: string) => {
-  const data = await apiClient.put(`${END_POINT.posts}/${postId}`, {
+interface CreatePostType {
+  title: string;
+  content: string;
+  category: string;
+  studyId: number;
+}
+
+export const createPost = async (post: CreatePostType) => {
+  const data = await apiClient.post<any, any>(`${END_POINT.posts}`, post, {
     headers: {
       Authorization: `Bearer ${token}`,
     },
   });
+  console.log(data, "포스트 생성");
+  return data;
+};
+
+export const putPost = async (postId: number, post: CreatePostType) => {
+  const data = await apiClient.put(`${END_POINT.posts}/${postId}`, post, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  console.log(data, "포스트 수정");
   return data;
 };

--- a/features/PostForm/PostForm.tsx
+++ b/features/PostForm/PostForm.tsx
@@ -1,0 +1,65 @@
+import { useState, ChangeEvent } from "react";
+import { MenuItem, TextField, SelectChangeEvent } from "@mui/material";
+import * as S from "./style";
+
+interface PostFormProp {
+  selectValue: string;
+  title: string;
+  content: string;
+}
+
+export const PostForm = ({ selectValue, title, content }: PostFormProp) => {
+  // TODO Prop으로 NOTICE인지 FREE인지 전달해줘야할 듯
+  // TODO title과 content 어떻게 서버로 보내지
+  const [postSelectValue, setPostSelectValue] = useState(selectValue);
+  const [postTitle, setPostTitle] = useState(title);
+  const [postContent, setPostContent] = useState(content);
+
+  const handleSelectChange = (event: SelectChangeEvent<unknown>) => {
+    setPostSelectValue(event.target.value as string);
+  };
+
+  const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setPostTitle(event.target.value);
+  };
+
+  const handleContentChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setPostContent(event.target.value);
+  };
+
+  return (
+    <S.Container>
+      <S.Title>
+        <S.StyledSelect
+          labelId="demo-simple-select-label"
+          id="demo-simple-select"
+          value={postSelectValue}
+          onChange={handleSelectChange}
+        >
+          <MenuItem value="NOTICE">공지</MenuItem>
+          <MenuItem value="FREE">자유</MenuItem>
+        </S.StyledSelect>
+        <S.StyledTextField
+          name="title"
+          variant="standard"
+          value={postTitle}
+          placeholder="제목을 입력해주세요"
+          margin="dense"
+          fullWidth
+          onChange={handleTitleChange}
+        />
+      </S.Title>
+      <TextField
+        name="content"
+        variant="outlined"
+        value={postContent}
+        placeholder="내용을 입력해주세요"
+        multiline
+        minRows={15}
+        margin="dense"
+        onChange={handleContentChange}
+      />
+      <S.StyledButton variant="contained">게시하기</S.StyledButton>
+    </S.Container>
+  );
+};

--- a/features/PostForm/PostForm.tsx
+++ b/features/PostForm/PostForm.tsx
@@ -7,7 +7,7 @@ import { createPost, putPost } from "../../apis";
 interface PostFormProp {
   state: string;
   selectValue: string;
-  postId: number;
+  postId?: number;
   title: string;
   content: string;
   studyId: number;
@@ -50,7 +50,7 @@ export const PostForm = ({
       const getPostId = await createPost(postObject);
       if (getPostId) router.push(`/post/${getPostId}`);
     } else if (state === "PUT") {
-      await putPost(postId, postObject);
+      await putPost(postId as number, postObject);
       router.push(`/post/${postId}`);
     }
   };

--- a/features/PostForm/PostForm.tsx
+++ b/features/PostForm/PostForm.tsx
@@ -1,20 +1,32 @@
 import { useState, ChangeEvent } from "react";
 import { MenuItem, TextField, SelectChangeEvent } from "@mui/material";
+import { useRouter } from "next/router";
 import * as S from "./style";
+import { createPost, putPost } from "../../apis";
 
 interface PostFormProp {
+  state: string;
   selectValue: string;
+  postId: number;
   title: string;
   content: string;
+  studyId: number;
 }
 
-export const PostForm = ({ selectValue, title, content }: PostFormProp) => {
-  // TODO Prop으로 NOTICE인지 FREE인지 전달해줘야할 듯
-  // TODO title과 content 어떻게 서버로 보내지
+export const PostForm = ({
+  state,
+  selectValue,
+  postId,
+  title,
+  content,
+  studyId,
+}: PostFormProp) => {
   const [postSelectValue, setPostSelectValue] = useState(selectValue);
   const [postTitle, setPostTitle] = useState(title);
   const [postContent, setPostContent] = useState(content);
 
+  const router = useRouter();
+  // TODO 스터디 장이 쓰고있는지 받아서 이 작동 못하게 해야함
   const handleSelectChange = (event: SelectChangeEvent<unknown>) => {
     setPostSelectValue(event.target.value as string);
   };
@@ -25,6 +37,22 @@ export const PostForm = ({ selectValue, title, content }: PostFormProp) => {
 
   const handleContentChange = (event: ChangeEvent<HTMLInputElement>) => {
     setPostContent(event.target.value);
+  };
+
+  const handleOnClick = async () => {
+    const postObject = {
+      title: postTitle,
+      content: postContent,
+      category: selectValue,
+      studyId,
+    };
+    if (state === "POST") {
+      const getPostId = await createPost(postObject);
+      if (getPostId) router.push(`/post/${getPostId}`);
+    } else if (state === "PUT") {
+      await putPost(postId, postObject);
+      router.push(`/post/${postId}`);
+    }
   };
 
   return (
@@ -59,7 +87,15 @@ export const PostForm = ({ selectValue, title, content }: PostFormProp) => {
         margin="dense"
         onChange={handleContentChange}
       />
-      <S.StyledButton variant="contained">게시하기</S.StyledButton>
+      {state === "POST" ? (
+        <S.StyledButton variant="contained" onClick={handleOnClick}>
+          게시하기
+        </S.StyledButton>
+      ) : (
+        <S.StyledButton variant="contained" onClick={handleOnClick}>
+          수정하기
+        </S.StyledButton>
+      )}
     </S.Container>
   );
 };

--- a/features/PostForm/index.ts
+++ b/features/PostForm/index.ts
@@ -1,0 +1,1 @@
+export { PostForm } from "./PostForm";

--- a/features/PostForm/style.tsx
+++ b/features/PostForm/style.tsx
@@ -1,0 +1,29 @@
+import styled from "@emotion/styled";
+import { Select, TextField, Button } from "@mui/material";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-item: center;
+`;
+
+export const Title = styled.div`
+  display: flex;
+`;
+
+export const StyledSelect = styled(Select)`
+  width: 10rem;
+  height: 3rem;
+  margin-right: 1rem;
+`;
+
+export const StyledTextField = styled(TextField)`
+  justify-content: flex-end;
+`;
+
+export const StyledButton = styled(Button)`
+  width: 6rem;
+  margin-left: auto;
+  white-space: nowrap;
+`;

--- a/features/PostForm/style.tsx
+++ b/features/PostForm/style.tsx
@@ -5,7 +5,6 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-item: center;
 `;
 
 export const Title = styled.div`

--- a/features/index.ts
+++ b/features/index.ts
@@ -2,3 +2,4 @@ export { StudyCardList } from "./StudyCardList";
 export { StudyDetail } from "./StudyDetail";
 export { Topbar } from "./Topbar";
 export { StudyOpen } from "./StudyOpen";
+export { PostForm } from "./PostForm";

--- a/pages/postCreate/index.tsx
+++ b/pages/postCreate/index.tsx
@@ -5,7 +5,6 @@ const PostCreatePage = () => {
   return (
     <PostForm
       state="POST"
-      postId={-1}
       selectValue="NOTICE"
       title=""
       content=""

--- a/pages/postCreate/index.tsx
+++ b/pages/postCreate/index.tsx
@@ -1,43 +1,7 @@
-import { useState } from "react";
-import { MenuItem, TextField, SelectChangeEvent } from "@mui/material";
-import * as S from "../../styles/PostCreatePageStyle";
+import { PostForm } from "../../features";
 
 const PostCreatePage = () => {
-  const [selectValue, setSelectValue] = useState("NOTION");
-  const handleChange = (event: SelectChangeEvent<unknown>) => {
-    setSelectValue(event.target.value as string);
-  };
-  return (
-    <S.Container>
-      <S.Title>
-        <S.StyledSelect
-          labelId="demo-simple-select-label"
-          id="demo-simple-select"
-          value={selectValue}
-          onChange={handleChange}
-        >
-          <MenuItem value="NOTION">공지</MenuItem>
-          <MenuItem value="FREE">자유</MenuItem>
-        </S.StyledSelect>
-        <S.StyledTextField
-          name="title"
-          variant="standard"
-          placeholder="제목을 입력해주세요"
-          margin="dense"
-          fullWidth
-        />
-      </S.Title>
-      <TextField
-        name="content"
-        variant="outlined"
-        placeholder="내용을 입력해주세요"
-        multiline
-        minRows={15}
-        margin="dense"
-      />
-      <S.StyledButton variant="contained">게시하기</S.StyledButton>
-    </S.Container>
-  );
+  return <PostForm selectValue="NOTICE" title="" content="" />;
 };
 
 export default PostCreatePage;

--- a/pages/postCreate/index.tsx
+++ b/pages/postCreate/index.tsx
@@ -1,7 +1,17 @@
 import { PostForm } from "../../features";
 
 const PostCreatePage = () => {
-  return <PostForm selectValue="NOTICE" title="" content="" />;
+  // TODO selectValue와 studyId 전달받아서 넣어주기
+  return (
+    <PostForm
+      state="POST"
+      postId={-1}
+      selectValue="NOTICE"
+      title=""
+      content=""
+      studyId={1}
+    />
+  );
 };
 
 export default PostCreatePage;

--- a/pages/postUpdate/[id].tsx
+++ b/pages/postUpdate/[id].tsx
@@ -1,0 +1,48 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { getPost } from "../../apis";
+import { PostForm } from "../../features";
+
+interface PostType {
+  id: number;
+  title: string;
+  content: string;
+  category: string;
+  studyId: number;
+  writer: string;
+  writerImage: string;
+  commentCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const postUpdatePage = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const [post, setPost] = useState({} as PostType);
+
+  useEffect(() => {
+    const getPostApi = async (postId: string) => {
+      const postData = await getPost(postId);
+      setPost(postData);
+    };
+    if (id) getPostApi(id as string);
+  }, [id, post]);
+
+  return (
+    <div>
+      {post.id && (
+        <PostForm
+          state="PUT"
+          selectValue={post.category}
+          postId={post.id}
+          title={post.title}
+          content={post.content}
+          studyId={post.studyId}
+        />
+      )}
+    </div>
+  );
+};
+
+export default postUpdatePage;


### PR DESCRIPTION
### 📌 설명
생성은 postCreate 페이지에서 하신 후 console에 뜨는 값으로
postUpdate/[id]로 이동하시면 수정하실 수 있습니다.

![ezgif com-gif-maker (17)](https://user-images.githubusercontent.com/65644486/184099374-d79c5b96-36b4-47e2-a613-38f63bee6dec.gif)

### 🎨 구현 내용
- postCreate 페이지와 기능
- postUpdate 페이지와 기능

#### 참고사항
- 타입은 나중에 한번에 분리하겠습니다.
- 스터디 장만 select로 공지 자유 원하는 곳에 글을 쓰도록 하고 권한이 없으면 select를 disable상태로 만들 생각입니다.

### ✅ 중점적으로 봐줬으면 하는 부분
에러와 개선사항이 있을까요?

### 🚀 연관된 이슈
close #114 