### PR TITLE
#109/feat/component skeleton

### DIFF
--- a/components/BookCard/BookCard.stories.tsx
+++ b/components/BookCard/BookCard.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { BookCard } from ".";
+import { BookCard, BookCardSkeleton } from ".";
 
 export default {
   title: "components/BookCard",
@@ -20,5 +20,20 @@ export const Default = Template.bind({});
 Default.args = {
   src: "https://i.picsum.photos/id/962/200/300.jpg?hmac=wvuv8EVOoNE5J3sBkBx-1wcVHNbgJ_Z1dS98YhnShjM",
   title: "Hello",
+  size: 10,
+};
+
+const SkeletonTemplate: ComponentStory<typeof BookCardSkeleton> = (args) => {
+  return (
+    <>
+      <BookCardSkeleton {...args} />
+      <br />
+      <BookCardSkeleton {...args} />
+    </>
+  );
+};
+
+export const Skeleton = SkeletonTemplate.bind({});
+Skeleton.args = {
   size: 10,
 };

--- a/components/BookCard/BookCardSkeleton.tsx
+++ b/components/BookCard/BookCardSkeleton.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from "@mui/material";
+import * as S from "./style";
+
+interface BookCardSkeletonProps {
+  size: number;
+}
+
+export const BookCardSkeleton = ({ size }: BookCardSkeletonProps) => {
+  return (
+    <>
+      <Skeleton
+        variant="rectangular"
+        width={`${size}rem`}
+        height={`${size * 1.25}rem`}
+      />
+      <S.BookTitle />
+    </>
+  );
+};

--- a/components/BookCard/BookCardSkeleton.tsx
+++ b/components/BookCard/BookCardSkeleton.tsx
@@ -7,13 +7,13 @@ interface BookCardSkeletonProps {
 
 export const BookCardSkeleton = ({ size }: BookCardSkeletonProps) => {
   return (
-    <>
+    <div>
       <Skeleton
         variant="rectangular"
         width={`${size}rem`}
         height={`${size * 1.25}rem`}
       />
       <S.BookTitle />
-    </>
+    </div>
   );
 };

--- a/components/BookCard/index.ts
+++ b/components/BookCard/index.ts
@@ -1,1 +1,2 @@
 export { BookCard } from "./BookCard";
+export { BookCardSkeleton } from "./BookCardSkeleton";

--- a/components/BookCard/style.tsx
+++ b/components/BookCard/style.tsx
@@ -30,4 +30,5 @@ export const BookTitle = styled.p`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  height: 1rem;
 `;

--- a/components/BookDetailCard/BookDetailCard.stories.tsx
+++ b/components/BookDetailCard/BookDetailCard.stories.tsx
@@ -1,12 +1,21 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { BookDetail } from ".";
+import { BookDetail, BookDetailSkeleton } from ".";
 
 export default {
   title: "components/BookDetail",
   component: BookDetail,
 } as ComponentMeta<typeof BookDetail>;
 
-const Template: ComponentStory<typeof BookDetail> = (args) => <BookDetail {...args} />;
+const Template: ComponentStory<typeof BookDetail> = (args) => (
+  <BookDetail {...args} />
+);
 
 export const Default = Template.bind({});
 Default.args = {};
+
+const SkeletonTemplate: ComponentStory<typeof BookDetailSkeleton> = (args) => (
+  <BookDetailSkeleton {...args} />
+);
+
+export const Skeleton = SkeletonTemplate.bind({});
+Skeleton.args = {};

--- a/components/BookDetailCard/BookDetailCardSkeleton.tsx
+++ b/components/BookDetailCard/BookDetailCardSkeleton.tsx
@@ -1,0 +1,29 @@
+import { Skeleton } from "@mui/material";
+import * as S from "./style";
+
+interface BookDetailCardSkeletonProps {
+  size: number;
+}
+
+export const BookDetailSkeleton = ({
+  size = 208,
+}: BookDetailCardSkeletonProps) => {
+  return (
+    <S.BookDetailCard>
+      <S.ImageContainer>
+        <Skeleton variant="rectangular" width={size} height={size * 1.5} />
+        <S.ButtonSkeleton variant="rectangular" />
+      </S.ImageContainer>
+      <S.BookInfoConatiner>
+        {[0, 1, 2, 3].map((key) => (
+          <S.TextSkeletonWrapper key={key} width="10rem" height="25px">
+            <S.FullHeightSkeleton variant="rectangular" />
+          </S.TextSkeletonWrapper>
+        ))}
+        <S.TextSkeletonWrapper width="100%" height="9rem">
+          <S.FullHeightSkeleton variant="rectangular" />
+        </S.TextSkeletonWrapper>
+      </S.BookInfoConatiner>
+    </S.BookDetailCard>
+  );
+};

--- a/components/BookDetailCard/index.ts
+++ b/components/BookDetailCard/index.ts
@@ -1,1 +1,2 @@
 export { BookDetail } from "./BookDetailCard";
+export { BookDetailSkeleton } from "./BookDetailCardSkeleton";

--- a/components/BookDetailCard/style.tsx
+++ b/components/BookDetailCard/style.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Card } from "@mui/material";
+import { Card, Skeleton } from "@mui/material";
 import Button from "@mui/material/Button";
 
 export const BookDetailCard = styled(Card)`
@@ -79,4 +79,24 @@ export const StyledButton = styled(Button)`
     position: relative;
     margin-bottom: 1rem;
   }
+`;
+
+export const ButtonSkeleton = styled(Skeleton)`
+  height: 2rem;
+  margin-top: 1rem;
+`;
+
+interface TextSkeletonWrapperProps {
+  width: string;
+  height: string;
+}
+
+export const TextSkeletonWrapper = styled.div<TextSkeletonWrapperProps>`
+  padding: 0.5rem;
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+`;
+
+export const FullHeightSkeleton = styled(Skeleton)`
+  height: 100%;
 `;

--- a/components/Comment/Comment.stories.tsx
+++ b/components/Comment/Comment.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { Comment } from ".";
+import { Comment, CommentSkeleton } from ".";
 
 export default {
   title: "components/Comment",
@@ -21,3 +21,10 @@ Default.args = {
   },
   content: " Lorem ipsum dolor sit ",
 };
+
+const SkeletonTemplate: ComponentStory<typeof CommentSkeleton> = (args) => (
+  <CommentSkeleton {...args} />
+);
+
+export const Skeleton = SkeletonTemplate.bind({});
+Skeleton.args = {};

--- a/components/Comment/CommentSkeleton.tsx
+++ b/components/Comment/CommentSkeleton.tsx
@@ -1,0 +1,22 @@
+import { Avatar, Skeleton } from "@mui/material";
+import * as S from "./style";
+
+interface CommentSkeletonProps {
+  size?: string;
+}
+
+export const CommentSkeleton = ({ size = "19px" }: CommentSkeletonProps) => {
+  return (
+    <S.CommentContainer>
+      <S.UserWrapper>
+        <Skeleton variant="circular">
+          <Avatar />
+        </Skeleton>
+        <S.CommentWriterSkeleton variant="rectangular" size={size} />
+      </S.UserWrapper>
+      <S.CommentContentSkeleton size={size}>
+        <Skeleton variant="rectangular" height="100%" />
+      </S.CommentContentSkeleton>
+    </S.CommentContainer>
+  );
+};

--- a/components/Comment/index.ts
+++ b/components/Comment/index.ts
@@ -1,1 +1,2 @@
 export { Comment } from "./Comment";
+export { CommentSkeleton } from "./CommentSkeleton";

--- a/components/Comment/style.tsx
+++ b/components/Comment/style.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { Skeleton } from "@mui/material";
 
 export const CommentContainer = styled.div`
   display: flex;
@@ -15,4 +16,19 @@ export const UserWrapper = styled.div`
   flex-direction: column;
   gap: 0.5rem;
   align-items: center;
+`;
+
+interface SkeletonProps {
+  size: string;
+}
+
+export const CommentWriterSkeleton = styled(Skeleton)<SkeletonProps>`
+  width: 100%;
+  height: ${({ size }) => size};
+`;
+
+export const CommentContentSkeleton = styled.div<SkeletonProps>`
+  margin: ${({ size }) => `${size} ${size} 0 0`};
+  width: 100%;
+  height: 67px;
 `;

--- a/components/PostCard/PostCard.stories.tsx
+++ b/components/PostCard/PostCard.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { PostCard } from ".";
+import { PostCard, PostCardSkeleton } from ".";
 
 export default {
   title: "components/PostCard",
@@ -32,3 +32,10 @@ Default.args = {
     },
   },
 };
+
+const SkeletonTemplate: ComponentStory<typeof PostCardSkeleton> = (args) => (
+  <PostCardSkeleton {...args} />
+);
+
+export const Skeleton = SkeletonTemplate.bind({});
+Skeleton.args = {};

--- a/components/PostCard/PostCardSkeleton.tsx
+++ b/components/PostCard/PostCardSkeleton.tsx
@@ -1,0 +1,35 @@
+import { Avatar, Divider, Skeleton } from "@mui/material";
+import { Chat } from "@mui/icons-material";
+import * as S from "./style";
+
+interface PostCardSkeletonProps {
+  size?: number;
+}
+
+export const PostCardSkeleton = ({ size = 20 }: PostCardSkeletonProps) => {
+  return (
+    <S.PostCard size={size}>
+      <Skeleton variant="rectangular" height="21px" />
+      <div style={{ marginTop: "0.5rem", height: "4rem" }}>
+        <Skeleton variant="rectangular" height="100%" />
+      </div>
+      <div style={{ margin: "0.5rem 0", height: "1rem" }}>
+        <Skeleton variant="rectangular" width="7rem" height="100%" />
+      </div>
+      <Divider light />
+      <S.PostBottomContainer>
+        <S.PostUserWarpper>
+          <Skeleton variant="circular">
+            <Avatar />
+          </Skeleton>
+          <S.PostCardWriterSkeleton>
+            <Skeleton variant="rectangular" width="100%" height="100%" />
+          </S.PostCardWriterSkeleton>
+        </S.PostUserWarpper>
+        <S.StyledBadge badgeContent="?" color="primary">
+          <Chat color="action" />
+        </S.StyledBadge>
+      </S.PostBottomContainer>
+    </S.PostCard>
+  );
+};

--- a/components/PostCard/index.ts
+++ b/components/PostCard/index.ts
@@ -1,1 +1,2 @@
 export { PostCard } from "./PostCard";
+export { PostCardSkeleton } from "./PostCardSkeleton";

--- a/components/PostCard/style.tsx
+++ b/components/PostCard/style.tsx
@@ -54,3 +54,9 @@ export const PostUserWarpper = styled.div`
   align-items: center;
   gap: 0.5rem;
 `;
+
+export const PostCardWriterSkeleton = styled.div`
+  flex-shrink: 0;
+  width: 10rem;
+  height: 19px;
+`;

--- a/components/StudyCard/StudyCard.stories.tsx
+++ b/components/StudyCard/StudyCard.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { StudyCard } from ".";
+import { StudyCard, StudyCardSkeleton } from ".";
 
 export default {
   title: "Components/StudyCard",
@@ -12,3 +12,8 @@ const Template: ComponentStory<typeof StudyCard> = (args) => {
 };
 
 export const Default = Template.bind({});
+
+const SkeletonTemplate: ComponentStory<typeof StudyCardSkeleton> = (args) => {
+  return <StudyCardSkeleton {...args} />;
+};
+export const Skeleton = SkeletonTemplate.bind({});

--- a/components/StudyCard/StudyCardSkeleton.tsx
+++ b/components/StudyCard/StudyCardSkeleton.tsx
@@ -1,0 +1,30 @@
+import { Skeleton } from "@mui/material";
+import * as S from "./style";
+
+interface StudyCardSkeletonProps {
+  size?: number;
+}
+
+export const StudyCardSkeleton = ({ size = 128 }: StudyCardSkeletonProps) => {
+  return (
+    <S.StudyCard>
+      <S.StudyThumbnailSkeleton width={size} height={size * 1.5}>
+        <Skeleton variant="rectangular" width={size} height="100%" />
+      </S.StudyThumbnailSkeleton>
+      <S.StudyInfoConatiner>
+        <S.StudyInfoSkeleton width="16rem" height="23px">
+          <Skeleton variant="rectangular" />
+        </S.StudyInfoSkeleton>
+        <S.StudyInfoSkeleton width="8rem" height="23px">
+          <Skeleton variant="rectangular" />
+        </S.StudyInfoSkeleton>
+        <S.StudyInfoSkeleton width="16rem" height="19px">
+          <Skeleton variant="rectangular" />
+        </S.StudyInfoSkeleton>
+        <S.StudyInfoSkeleton width="16rem" height="19px">
+          <Skeleton variant="rectangular" />
+        </S.StudyInfoSkeleton>
+      </S.StudyInfoConatiner>
+    </S.StudyCard>
+  );
+};

--- a/components/StudyCard/index.ts
+++ b/components/StudyCard/index.ts
@@ -1,1 +1,2 @@
 export { StudyCard } from "./StudyCard";
+export { StudyCardSkeleton } from "./StudyCardSkeleton";

--- a/components/StudyCard/style.tsx
+++ b/components/StudyCard/style.tsx
@@ -38,3 +38,24 @@ export const ResponsiveText = styled.div<ResponsiveTextProps>`
     font-size: 0.8rem;
   }
 `;
+
+interface StudyThumbnailSkeletonProps {
+  width: number;
+  height: number;
+}
+
+export const StudyThumbnailSkeleton = styled.div<StudyThumbnailSkeletonProps>`
+  width: ${({ width }) => `${width}px`};
+  height: ${({ height }) => `${height}px`};
+`;
+
+interface StudyInfoSkeletonProps {
+  width: string;
+  height: string;
+}
+
+export const StudyInfoSkeleton = styled.div<StudyInfoSkeletonProps>`
+  padding: 0.5rem;
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+`;

--- a/components/StudyDetailCard/StudyDetailCard.stories.tsx
+++ b/components/StudyDetailCard/StudyDetailCard.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { StudyDetailCard } from ".";
+import { StudyDetailCard, StudyDetailCardSkeleton } from ".";
 
 export default {
   title: "components/StudyDetailCard",
@@ -48,3 +48,8 @@ Default.args = {
     },
   ],
 };
+
+const SkeletonTemplate: ComponentStory<typeof StudyDetailCardSkeleton> = (
+  args
+) => <StudyDetailCardSkeleton {...args} />;
+export const Skeleton = SkeletonTemplate.bind({});

--- a/components/StudyDetailCard/StudyDetailCardSkeleton.tsx
+++ b/components/StudyDetailCard/StudyDetailCardSkeleton.tsx
@@ -1,0 +1,34 @@
+import { Avatar, AvatarGroup, Skeleton } from "@mui/material";
+import { BookCardSkeleton } from "../BookCard";
+import * as S from "./style";
+
+interface StudyDetailCardSkeletonProps {
+  size?: number;
+}
+
+export const StudyDetailCardSkeleton = ({
+  size = 10,
+}: StudyDetailCardSkeletonProps) => {
+  return (
+    <S.StudyDetailCard>
+      <BookCardSkeleton size={size} />
+      <S.StudyInfoContainerSkeleton>
+        <S.StudyTypographSkeleton>
+          <Skeleton variant="rectangular" height="100%" />
+        </S.StudyTypographSkeleton>
+        <S.StudyText>
+          <Skeleton variant="rectangular" height="100%" />
+        </S.StudyText>
+        <S.StudyText>
+          <Skeleton variant="rectangular" height="100%" />
+        </S.StudyText>
+      </S.StudyInfoContainerSkeleton>
+      <S.AvartarGroupContainerSkeleton>
+        <AvatarGroup>
+          <Avatar />
+          <Avatar />
+        </AvatarGroup>
+      </S.AvartarGroupContainerSkeleton>
+    </S.StudyDetailCard>
+  );
+};

--- a/components/StudyDetailCard/index.ts
+++ b/components/StudyDetailCard/index.ts
@@ -1,1 +1,2 @@
 export { StudyDetailCard } from "./StudyDetailCard";
+export { StudyDetailCardSkeleton } from "./StudyDetailCardSkeleton";

--- a/components/StudyDetailCard/style.tsx
+++ b/components/StudyDetailCard/style.tsx
@@ -70,3 +70,23 @@ export const ResponsiveText = styled.div<ResponsiveTextProps>`
   padding: 0.5rem;
   font-size: ${({ fontSize }) => `${fontSize}rem`};
 `;
+
+export const StudyInfoContainerSkeleton = styled.div`
+  width: 609px;
+  padding: 1rem;
+  padding-top: 0;
+`;
+
+export const StudyTypographSkeleton = styled.div`
+  height: 8rem;
+`;
+
+export const StudyText = styled.div`
+  width: 16rem;
+  height: 19px;
+  padding: 0.5rem 0;
+`;
+
+export const AvartarGroupContainerSkeleton = styled.div`
+  flex-grow: 1;
+`;

--- a/components/index.ts
+++ b/components/index.ts
@@ -4,3 +4,4 @@ export { Spacer } from "./Spacer";
 export { StudyCard } from "./StudyCard";
 export { StudyContent } from "./StudyContent";
 export { TabPanel } from "./TabPanel";
+export { Comment, CommentSkeleton } from "./Comment";

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,4 +1,4 @@
-export { BookCard } from "./BookCard";
+export { BookCard, BookCardSkeleton } from "./BookCard";
 export { BookDetail } from "./BookDetailCard";
 export { Spacer } from "./Spacer";
 export { StudyCard } from "./StudyCard";

--- a/components/index.ts
+++ b/components/index.ts
@@ -5,3 +5,4 @@ export { StudyCard } from "./StudyCard";
 export { StudyContent } from "./StudyContent";
 export { TabPanel } from "./TabPanel";
 export { Comment, CommentSkeleton } from "./Comment";
+export { PostCard, PostCardSkeleton } from "./PostCard";

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,7 +1,7 @@
 export { BookCard, BookCardSkeleton } from "./BookCard";
 export { BookDetail, BookDetailSkeleton } from "./BookDetailCard";
 export { Spacer } from "./Spacer";
-export { StudyCard } from "./StudyCard";
+export { StudyCard, StudyCardSkeleton } from "./StudyCard";
 export { StudyContent } from "./StudyContent";
 export { TabPanel } from "./TabPanel";
 export { Comment, CommentSkeleton } from "./Comment";

--- a/components/index.ts
+++ b/components/index.ts
@@ -6,3 +6,4 @@ export { StudyContent } from "./StudyContent";
 export { TabPanel } from "./TabPanel";
 export { Comment, CommentSkeleton } from "./Comment";
 export { PostCard, PostCardSkeleton } from "./PostCard";
+export { StudyDetailCard, StudyDetailCardSkeleton } from "./StudyDetailCard";

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,5 +1,5 @@
 export { BookCard, BookCardSkeleton } from "./BookCard";
-export { BookDetail } from "./BookDetailCard";
+export { BookDetail, BookDetailSkeleton } from "./BookDetailCard";
 export { Spacer } from "./Spacer";
 export { StudyCard } from "./StudyCard";
 export { StudyContent } from "./StudyContent";

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import type { ChangeEvent } from "react";
 import { getNaverBooks, registerBook } from "../../apis";
-import { BookCard } from "../../components";
+import { BookCard, BookCardSkeleton } from "../../components";
 import type {
   NaverBookResponseType,
   NaverBookType,
@@ -94,7 +94,11 @@ const SearchPage = () => {
   }, [router.query]);
 
   return loading ? (
-    "로딩 중"
+    <S.BookCardContainer>
+      {Array.from({ length: 10 }, (_, idx) => idx).map((id) => (
+        <BookCardSkeleton key={id} size={10} />
+      ))}
+    </S.BookCardContainer>
   ) : (
     <>
       <S.BookCardContainer>


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

컴포넌트별 스켈레톤을 만들었습니다
스토리북에서 확인이 가능합니다

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

- 컴포넌트별로 스켈레톤을 개발했습니다
- 사용할 때 로딩 state를 구분하고, 로딩중이면 아래와 같이 할 수 있습니다
![검색 스켈레톤](https://user-images.githubusercontent.com/50919342/184118569-4f436474-b297-4bbf-8e2a-e9931e1c061c.gif)
- 다른 페이지에는 충돌이나 로직변경을 염려하여 적용하지 않았고, 검색 페이지에만 스켈레톤을 적용했습니다

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

- BookDetail만 컴포넌트의 이미지 사이즈가 변하는데 어떻게 변하는건지를 모르겠어서 스켈레톤이 다를 수 있습니다

### 🚀 연관된 이슈
close issue #109 