### PR TITLE
#145/feat/study open 마무리 - 상태 관련 핸들링, 뒤로가기 등

### DIFF
--- a/features/StudyOpen/StudyOpen.tsx
+++ b/features/StudyOpen/StudyOpen.tsx
@@ -247,6 +247,10 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
     };
   };
 
+  const handleBackClick = () => {
+    router.back();
+  };
+
   if (!user)
     return (
       <NoAccess
@@ -450,6 +454,9 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
       </S.LowerContainer>
       <S.StudyOpenButton variant="outlined" onClick={handleOpenClick}>
         {studyId ? "스터디 수정하기" : "스터디 개설하기"}
+      </S.StudyOpenButton>
+      <S.StudyOpenButton variant="outlined" onClick={handleBackClick}>
+        뒤로가기
       </S.StudyOpenButton>
     </S.EntierContainer>
   );

--- a/features/StudyOpen/StudyOpen.tsx
+++ b/features/StudyOpen/StudyOpen.tsx
@@ -378,11 +378,7 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
             <TextField
               select
               fullWidth
-              disabled={
-                !studyId ||
-                studyInfo.status === "inProgress" ||
-                studyInfo.status === "finished"
-              }
+              disabled={!studyId || studyInfo.status !== "recruiting"}
               name="status"
               variant="standard"
               label="스터디 모집 상태"

--- a/features/StudyOpen/StudyOpen.tsx
+++ b/features/StudyOpen/StudyOpen.tsx
@@ -385,7 +385,12 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
               value={studyInfo.status}
               onChange={handleStudyInfoChange}
               error={!!inputError.status}
-              helperText={inputError.status}
+              helperText={
+                inputError.status ||
+                (studyId &&
+                  studyInfo.status === "recruiting" &&
+                  "모집 완료로 변경 시 다시 모집 중으로 되돌릴 수 없습니다.")
+              }
             >
               <MenuItem key="status-recruiting" value="recruiting">
                 {STATUS.recruiting}

--- a/features/StudyOpen/StudyOpen.tsx
+++ b/features/StudyOpen/StudyOpen.tsx
@@ -85,6 +85,9 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
     status: "",
   });
   const [isOwner, setIsOwner] = useState(true);
+  const [initStatus, setInitStatus] = useState<
+    StudyStatusType | null | undefined
+  >();
   const { user } = useUserContext();
 
   const router = useRouter();
@@ -118,6 +121,7 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
       const { title: bookTitle } = book;
 
       setIsOwner(user?.id === members[0].user.id || false);
+      setInitStatus(status);
 
       setStudyInfo({
         ...studyInfo,
@@ -382,7 +386,7 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
             <TextField
               select
               fullWidth
-              disabled={!studyId || studyInfo.status !== "recruiting"}
+              disabled={!studyId || initStatus !== "recruiting"}
               name="status"
               variant="standard"
               label="스터디 모집 상태"
@@ -392,7 +396,6 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
               helperText={
                 inputError.status ||
                 (studyId &&
-                  studyInfo.status === "recruiting" &&
                   "모집 완료로 변경 시 다시 모집 중으로 되돌릴 수 없습니다.")
               }
             >

--- a/features/Topbar/UserProfile/UserProfile.tsx
+++ b/features/Topbar/UserProfile/UserProfile.tsx
@@ -23,10 +23,12 @@ export const UserProfile = () => {
 
   const handleAvatarClick = () => {
     router.push(`/userProfile/${user?.id}`);
+    setAnchorEl(null);
   };
 
   const handleStudyClick = (studyId: number) => {
     router.push(`/study/${studyId}`);
+    setAnchorEl(null);
   };
 
   const handleLogoutModalOpen = () => {

--- a/pages/userProfileEdit/index.tsx
+++ b/pages/userProfileEdit/index.tsx
@@ -58,6 +58,10 @@ const UserProfileEditPage = () => {
     }
   };
 
+  const handleBackClick = () => {
+    router.back();
+  };
+
   useEffect(() => {
     setImageUrl(image);
   }, [image]);
@@ -107,7 +111,9 @@ const UserProfileEditPage = () => {
             <S.StyledButton variant="contained" onClick={handleUserInfoUpdate}>
               수정하기
             </S.StyledButton>
-            <S.StyledButton variant="contained">뒤로가기</S.StyledButton>
+            <S.StyledButton variant="contained" onClick={handleBackClick}>
+              뒤로가기
+            </S.StyledButton>
           </S.ButtonContainer>
         </>
       ) : (


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
<img width="972" alt="image" src="https://user-images.githubusercontent.com/19660039/184500614-01c2f024-e8cf-4744-8050-a2b190ec6c8f.png">
<img width="478" alt="image" src="https://user-images.githubusercontent.com/19660039/184500650-3490ecfa-2a7e-41e4-8625-49a16f1c22d1.png">


스터디 개설/수정 페이지 마무리를 위한 자잘한 기능 추가

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

- 모집 중을 제외하곤 상태 변경 불가능
- 모집 중 -> 모집 완료로 상태 변경할 경우 복구 불가능이라는 헬퍼텍스트 추가
- 뒤로가기 버튼

- 탑바 유저프로필에서 라우팅 시 유저프로필 닫기
- 유저프로필 수정 페이지에서 뒤로가기 버튼 클릭 시 back으로 라우팅


### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

jpg, jpeg 문제가 해결이 안되고 있군요... 리나님 코드를 그대로 재꺼에다 박아놓고 한 번 실험을 해보고 있겠습니다.

### 🚀 연관된 이슈
close #145 