### PR TITLE
#149/feat/study detail null - 스터디 모집 로딩 구현

### DIFF
--- a/features/StudyDetail/StudyDetail.tsx
+++ b/features/StudyDetail/StudyDetail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import {
   Divider,
   CircularProgress as CircularLoading,
+  Box,
 } from "@mui/material";
 import { useRouter } from "next/router";
 import type { StudyType } from "../../types/studyType";
@@ -119,7 +120,15 @@ export const StudyDetail = ({
           </LoginRequestModal.Container>
         </>
       ) : (
-        <CircularLoading />
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            alignItem: "center",
+          }}
+        >
+          <CircularLoading />
+        </Box>
       )}
     </div>
   );

--- a/features/StudyDetail/StudyDetail.tsx
+++ b/features/StudyDetail/StudyDetail.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from "react";
-import { Divider } from "@mui/material";
+import {
+  Divider,
+  CircularProgress as CircularLoading,
+} from "@mui/material";
 import { useRouter } from "next/router";
 import type { StudyType } from "../../types/studyType";
 import { StudyContent } from "../../components/StudyContent";
@@ -89,26 +92,35 @@ export const StudyDetail = ({
 
   return (
     <div>
-      <StudyDetailCard study={studyInfo.study} members={studyInfo.members} />
-      <Divider color="grey" />
-      <StudyContent
-        description={studyInfo.study.description}
-        isMember={isMember}
-        joinOnClick={handleStudyJoinClick}
-        goStudyOnClick={handleGoStudyClick}
-        height={isPage ? "40vh" : 10}
-      />
-      <LoginRequestModal.Container
-        open={openModal}
-        onClose={handleOnCloseClick}
-      >
-        <LoginRequestModal.Title>
-          스터디 참여하기 위해서 로그인이 필요합니다
-        </LoginRequestModal.Title>
-        <LoginRequestModal.Content>
-          로그인을 하시겠습니까?
-        </LoginRequestModal.Content>
-      </LoginRequestModal.Container>
+      {studyInfo.study.id ? (
+        <>
+          <StudyDetailCard
+            study={studyInfo.study}
+            members={studyInfo.members}
+          />
+          <Divider color="grey" />
+          <StudyContent
+            description={studyInfo.study.description}
+            isMember={isMember}
+            joinOnClick={handleStudyJoinClick}
+            goStudyOnClick={handleGoStudyClick}
+            height={isPage ? "40vh" : 10}
+          />
+          <LoginRequestModal.Container
+            open={openModal}
+            onClose={handleOnCloseClick}
+          >
+            <LoginRequestModal.Title>
+              스터디 참여하기 위해서 로그인이 필요합니다
+            </LoginRequestModal.Title>
+            <LoginRequestModal.Content>
+              로그인을 하시겠습니까?
+            </LoginRequestModal.Content>
+          </LoginRequestModal.Container>
+        </>
+      ) : (
+        <CircularLoading />
+      )}
     </div>
   );
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -28,3 +28,7 @@ a {
 .css-tbudox {
   margin: auto;
 }
+
+.css-yttchs {
+  outline: none;
+}


### PR DESCRIPTION
### 📌 설명
스터디 모집 페이지 로딩 구현입니다.
![image](https://user-images.githubusercontent.com/65644486/184500654-fbc076f4-84ae-4e9c-9629-535c8b551103.png)


### 🎨 구현 내용
- 모달 outline 때문에 로딩원에서 이렇게 보이는 문제가 생겨 globals에 outline: none을 추가했습니다...
![image](https://user-images.githubusercontent.com/65644486/184500959-d8ca9e21-d4b1-4f28-8c2a-388d61488048.png)

### ✅ 중점적으로 봐줬으면 하는 부분

### 🚀 연관된 이슈
close #149 