### PR TITLE
Fix: PostCard 

### DIFF
--- a/components/PostCard/style.tsx
+++ b/components/PostCard/style.tsx
@@ -7,6 +7,8 @@ export const PostCard = styled.div`
   flex-direction: column;
   gap: 0.5rem;
   padding: 0.5rem;
+  margin: 1rem 0;
+  border: 0.5px solid #f9f9f9;
   box-shadow: 12px 21px 15px -3px rgba(0, 0, 0, 0.1);
   cursor: pointer;
 `;
@@ -14,16 +16,20 @@ export const PostCard = styled.div`
 export const PostTitle = styled.div`
   font-weight: bold;
   font-size: large;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 export const PostContent = styled.div`
   padding-top: 0.5rem;
   text-overflow: ellipsis;
-  overflow: hidden;
   display: -webkit-box;
+  overflow: hidden;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  height: 4rem;
+  line-height: 1.5rem;
+  height: 5rem;
 `;
 
 export const PostCreatedAt = styled.div`


### PR DESCRIPTION
### 📌 설명
PostCard text가 잘리는 문제 해결했습니다.

![image](https://user-images.githubusercontent.com/65644486/184502869-8279e13b-e5a5-419d-b836-7bbfc869dec6.png)


### 🎨 구현 내용
맥북에서도 텍스트 안잘리고 문제없이 보이는 것 같습니다.

배경도 흰색 포스트카드도 흰색이라 구분이 잘안가는 것 같아서 아주 연한 border를 넣었습니다.
![image](https://user-images.githubusercontent.com/65644486/184502912-d41f0c83-e0ec-4b81-9f8f-82d453fa5f29.png)

postCard 위아래 간격을 1rem 추가했습니다.

### ✅ 중점적으로 봐줬으면 하는 부분

### 🚀 연관된 이슈
close #155 