### PR TITLE
#160/fix/탑바 개설한 스터디 안뜨는 문제 해결

### DIFF
--- a/apis/index.ts
+++ b/apis/index.ts
@@ -22,6 +22,7 @@ export { postImage } from "./image";
 export { getPosts, getPost, createPost, putPost, delPost } from "./post";
 
 export {
+  getMyInfo,
   getUser,
   putUser,
   getOpenStudy,

--- a/features/StudyOpen/StudyOpen.tsx
+++ b/features/StudyOpen/StudyOpen.tsx
@@ -8,10 +8,14 @@ import {
   getStudyDetailInfo,
   updateStudy,
   postImage,
+  getMyInfo,
 } from "../../apis";
 import { NoAccess } from "../../components/NoAccess";
 import { useOurSnackbar } from "../../hooks/useOurSnackbar";
-import { useUserContext } from "../../hooks/useUserContext";
+import {
+  useUserActionContext,
+  useUserContext,
+} from "../../hooks/useUserContext";
 import type { StudyStatusType } from "../../types/studyType";
 import * as S from "./style";
 
@@ -89,6 +93,7 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
     StudyStatusType | null | undefined
   >();
   const { user } = useUserContext();
+  const { login } = useUserActionContext();
 
   const router = useRouter();
   const { renderSnackbar } = useOurSnackbar();
@@ -214,7 +219,10 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
 
       if (!studyId) {
         const newStudyId = await createStudy({ newStudyInfo, token });
-
+        const updateUser = await getMyInfo(token);
+        console.log(updateUser.studies);
+        login(updateUser);
+        
         router.push({
           pathname: `/study/${newStudyId}`,
         });

--- a/features/StudyOpen/StudyOpen.tsx
+++ b/features/StudyOpen/StudyOpen.tsx
@@ -220,9 +220,8 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
       if (!studyId) {
         const newStudyId = await createStudy({ newStudyInfo, token });
         const updateUser = await getMyInfo(token);
-        console.log(updateUser.studies);
         login(updateUser);
-        
+
         router.push({
           pathname: `/study/${newStudyId}`,
         });

--- a/features/Topbar/Topbar.tsx
+++ b/features/Topbar/Topbar.tsx
@@ -12,7 +12,7 @@ import { useOurSnackbar } from "../../hooks/useOurSnackbar";
 
 const SEARCH_URL = "/search";
 const SEARCH_URL_SIZE = 6;
-const LOGO_SIZE = 64;
+const LOGO_SIZE = 40;
 
 interface TopbarProps {
   message: string;

--- a/features/Topbar/UserProfile/style.tsx
+++ b/features/Topbar/UserProfile/style.tsx
@@ -13,7 +13,7 @@ export const AvatarWrapper = styled("div")`
   padding: 0.5rem 1rem;
   align-items: center;
   gap: 1rem;
-  width: fit-content;
+  width: 100%;
   font-size: 1.2rem;
 
   cursor: pointer;


### PR DESCRIPTION
### 📌 설명
- 스터디 개설 후 탑바 모달에 개설한 스터디가 새로고침 해야 반영되는 문제 해결
![image](https://user-images.githubusercontent.com/65644486/184525479-63864a6c-40a7-49d6-a901-294d6bc1a721.png)

### 🎨 구현 내용

- 프로필 hover 시 전체를 인식하지 않는 것 같아 width를 조정했습니다.
![image](https://user-images.githubusercontent.com/65644486/184525510-919c5e95-2201-4036-a863-882556a634c2.png)

- 스터디 개설할 때 user정보 가져오는 Api 호출 후 Context에 저장하고있는 전역 user를 업데이트 해줬습니다.
```
const newStudyId = await createStudy({ newStudyInfo, token });
const updateUser = await getMyInfo(token);
login(updateUser);
```
### ✅ 중점적으로 봐줬으면 하는 부분

### 🚀 연관된 이슈
close #160 