### PR TITLE
#163/fix/image upload size

### DIFF
--- a/features/StudyOpen/StudyOpen.tsx
+++ b/features/StudyOpen/StudyOpen.tsx
@@ -330,6 +330,12 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
               InputLabelProps={{
                 shrink: true,
               }}
+              InputProps={{
+                inputProps: {
+                  max: 10,
+                  min: 1,
+                },
+              }}
             />
           </S.TextFieldWrapper>
           <S.TextFieldWrapper>

--- a/features/StudyOpen/StudyOpen.tsx
+++ b/features/StudyOpen/StudyOpen.tsx
@@ -236,6 +236,12 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
     if (!e.target.files) return;
     const file = e.target.files[0];
 
+    const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1MB
+    if (file.size >= MAX_FILE_SIZE) {
+      renderSnackbar("업로드할 수 있는 파일 크기는 최대 1MB입니다.", "error");
+      return;
+    }
+
     const reader = new FileReader();
     reader.readAsDataURL(file);
 

--- a/features/StudyOpen/StudyOpen.tsx
+++ b/features/StudyOpen/StudyOpen.tsx
@@ -145,6 +145,15 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
   const handleStudyInfoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name: inputName, value } = e.target;
 
+    if (inputName === "name") {
+      setStudyInfo({
+        ...studyInfo,
+        name: value.trim(),
+      });
+
+      return;
+    }
+
     setStudyInfo({
       ...studyInfo,
       [inputName]: value,
@@ -164,11 +173,11 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
     };
 
     const LIMIT_PARTICIPANT = 10;
-    const LIMIT_NAME = 30;
+    const LIMIT_NAME = 20;
 
     if (!studyInfo.name) newError.name = "스터디 이름을 입력해주세요";
     else if (studyInfo.name.length > LIMIT_NAME)
-      newError.name = "스터디 이름은 최대 30자입니다.";
+      newError.name = `스터디 이름은 최대 ${LIMIT_NAME}자입니다.`;
 
     if (!studyId) {
       if (!studyInfo.maxParticipant)
@@ -299,7 +308,7 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
               fullWidth
               name="name"
               variant="standard"
-              label="스터디 이름 (최대 30자)"
+              label="스터디 이름 (최대 20자)"
               value={studyInfo.name}
               onChange={handleStudyInfoChange}
               error={!!inputError.name}

--- a/features/StudyOpen/StudyOpen.tsx
+++ b/features/StudyOpen/StudyOpen.tsx
@@ -1,7 +1,7 @@
 import { MenuItem, TextField } from "@mui/material";
 import Image from "next/image";
 import { useRouter } from "next/router";
-import React, { ChangeEvent, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState, useRef } from "react";
 import {
   getBookInfo,
   createStudy,
@@ -85,9 +85,9 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
     status: "",
   });
   const [isOwner, setIsOwner] = useState(true);
-  const [initStatus, setInitStatus] = useState<
-    StudyStatusType | null | undefined
-  >();
+
+  const initStatusRef = useRef<StudyStatusType | null | undefined>();
+
   const { user } = useUserContext();
 
   const router = useRouter();
@@ -121,7 +121,7 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
       const { title: bookTitle } = book;
 
       setIsOwner(user?.id === members[0].user.id || false);
-      setInitStatus(status);
+      initStatusRef.current = status;
 
       setStudyInfo({
         ...studyInfo,
@@ -239,6 +239,8 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
     const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1MB
     if (file.size >= MAX_FILE_SIZE) {
       renderSnackbar("업로드할 수 있는 파일 크기는 최대 1MB입니다.", "error");
+
+      e.target.value = "";
       return;
     }
 
@@ -253,6 +255,7 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
         });
 
         setStudyInfo({ ...studyInfo, thumbnail: newImageUrl });
+        e.target.value = "";
       })();
     };
   };
@@ -392,7 +395,7 @@ export const StudyOpen = ({ bookId, studyId }: StudyOpenProps) => {
             <TextField
               select
               fullWidth
-              disabled={!studyId || initStatus !== "recruiting"}
+              disabled={!studyId || initStatusRef.current !== "recruiting"}
               name="status"
               variant="standard"
               label="스터디 모집 상태"

--- a/features/Topbar/UserProfile/style.tsx
+++ b/features/Topbar/UserProfile/style.tsx
@@ -13,7 +13,7 @@ export const AvatarWrapper = styled("div")`
   padding: 0.5rem 1rem;
   align-items: center;
   gap: 1rem;
-  width: fit-content;
+  width: 100%;
   font-size: 1.2rem;
 
   cursor: pointer;

--- a/pages/userProfileEdit/index.tsx
+++ b/pages/userProfileEdit/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../hooks/useUserContext";
 import { getMyInfo } from "../../apis/user";
 import * as S from "../../styles/UserProfileEditStyle";
+import { useOurSnackbar } from "../../hooks/useOurSnackbar";
 
 const UserProfileEditPage = () => {
   const router = useRouter();
@@ -22,10 +23,19 @@ const UserProfileEditPage = () => {
   const [username, setUserName] = useState(user ? user.name : "");
   const [isUserExist, setIsUserExist] = useState(false);
   const imageRef = useRef<HTMLInputElement>(null);
+  const { renderSnackbar } = useOurSnackbar();
 
   const handleChangeImage = async (e: any) => {
     const reader = new FileReader();
     const [file] = e.target.files;
+
+    const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1MB
+    if (file.size >= MAX_FILE_SIZE) {
+      renderSnackbar("업로드할 수 있는 파일 크기는 최대 1MB입니다.", "error");
+
+      return;
+    }
+
     if (file) {
       reader.readAsDataURL(file);
       reader.onload = () => setImage(reader.result as string);

--- a/pages/userProfileEdit/index.tsx
+++ b/pages/userProfileEdit/index.tsx
@@ -32,7 +32,7 @@ const UserProfileEditPage = () => {
     const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1MB
     if (file.size >= MAX_FILE_SIZE) {
       renderSnackbar("업로드할 수 있는 파일 크기는 최대 1MB입니다.", "error");
-
+      e.target.value = "";
       return;
     }
 
@@ -41,6 +41,7 @@ const UserProfileEditPage = () => {
       reader.onload = () => setImage(reader.result as string);
       const imageData = await postImage({ token, file });
       setImageUrl(imageData);
+      e.target.value = "";
     }
   };
 


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

이미지 업로드 api의 최대 허용 용량이 1mb인 관계로 관련 버그를 픽스하였습니ㅏㄷ.

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

![스터디오픈버그픽스](https://user-images.githubusercontent.com/19660039/184527859-81a16215-d1a3-4acb-8cb3-4cb8b12b065f.gif)


- studyOpen 컴포넌트 (스터디 개설, 수정)에서 이미지 업로드 시 1mb가 넘으면 error snackbar
- userProfileEdit에서 이미지 업로드 시 1mb가 넘으면 error snackbar
- 같은 사진 다시 선택 가능 (이전엔 inputChange에만 이라서 같은 사진이면 handler 호출 x)


<img width="277" alt="image" src="https://user-images.githubusercontent.com/19660039/184525837-bb81391a-809e-435c-a47c-7e9739fe6639.png">
- topbar userprofilee avatar wrapper 간단한 스타일링

- 스터디 이름에 띄어쓰기 trim

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

### 🚀 연관된 이슈
close #163 