### PR TITLE
feat: StudyCard hover 효과 추가

### DIFF
--- a/components/StudyCard/style.tsx
+++ b/components/StudyCard/style.tsx
@@ -4,6 +4,10 @@ import { Card } from "@mui/material";
 export const StudyCard = styled(Card)`
   display: flex;
   padding: 1rem;
+  cursor: pointer;
+  &:hover {
+    transform: scale(1.01) translateY(-10px);
+  }
 `;
 
 export const ImageWrapper = styled.div`

--- a/features/StudyCardList/StudyCardList.tsx
+++ b/features/StudyCardList/StudyCardList.tsx
@@ -20,7 +20,6 @@ export const StudyCardList = ({ studies }: StudyCardListProps) => {
 
   const handleCloseClick = () => setOpen(false);
 
-  // TODO 추후 Skeleton 추가
   return (
     <>
       <S.StudyCardContainer>

--- a/features/StudyCardList/style.tsx
+++ b/features/StudyCardList/style.tsx
@@ -12,7 +12,8 @@ export const StyledBox = styled(Box)`
 `;
 
 export const StudyCardContainer = styled.div`
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
 `;
 
 export const NotStudy = styled.div`


### PR DESCRIPTION
### 📌 설명
스터디 카드 hover 시 액션 추가했습니다.
![ezgif com-gif-maker (18)](https://user-images.githubusercontent.com/65644486/184526884-350675d5-6176-44ff-ac85-9b1762258265.gif)


### 🎨 구현 내용
스터디 카드 hover 시 커지는 액션 추가했습니다.
카드가 커짐에 따라 스크롤이 생겨 overflow-x: hidden으로 했습니다.

### ✅ 중점적으로 봐줬으면 하는 부분

### 🚀 연관된 이슈
close #166 