### PR TITLE
#170/book detail image error

### DIFF
--- a/components/BookDetailCard/BookDetailCard.tsx
+++ b/components/BookDetailCard/BookDetailCard.tsx
@@ -39,7 +39,17 @@ export const BookDetail = ({ size = 208, book }: BookDetailProps) => {
     <S.BookDetailCard>
       <S.ImageContainer>
         <S.ImageWrapper>
-          <Image width={size} height={size * 1.5} src={image} />
+          {image ? (
+            <Image width={size} height={size * 1.5} src={image} />
+          ) : (
+            <div
+              style={{
+                width: `${size}`,
+                height: `${size * 1.5}`,
+                backgroundColor: "lightgray",
+              }}
+            />
+          )}
         </S.ImageWrapper>
         <S.StyledButton
           variant="contained"


### PR DESCRIPTION
### 📌 설명
- BookDetail 페이지에서 뜨던 이미지 에러를 해결했습니다.
![image](https://user-images.githubusercontent.com/65644486/184534561-bf0fd57d-8fed-4f4c-9e28-045258285385.png)

- BookDetail 페이지에서 뜨던 고유 키값을 주라는 에러 해결했습니다.
![image](https://user-images.githubusercontent.com/65644486/184534589-c0cfe5ac-e8df-40fe-9546-e380b984a441.png)


### 🎨 구현 내용
- BookDetail 페이지에서 뜨던 이미지 에러를 해결했습니다.
=> image가 없으면 회색 배경을 보이도록 했습니다.

- BookDetail 페이지에서 뜨던 고유 키값을 주라는 에러 해결했습니다.
=> 고유 값을 주는 nanoid를 설치했습니다.


### ✅ 중점적으로 봐줬으면 하는 부분

### 🚀 연관된 이슈
close #170 