### PR TITLE
fix: next 기본 dark mode 스타일 삭제

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,7 +32,6 @@ const Home = ({ books }: ServerSidePropsType) => {
       <HomeUI />
       <S.StyledSpan>가장 많은 스터디가 개설된 책</S.StyledSpan>
       <Slider
-        dots
         autoplay
         infinite
         pauseOnHover

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,16 +15,6 @@ a {
   box-sizing: border-box;
 }
 
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
-  body {
-    color: white;
-    background: black;
-  }
-}
-
 .css-tbudox {
   margin: auto;
 }


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

OS 다크모드가 설정되어 있으면 로그인 모달과 Tab이 보이지 않던 현상을 수정했습니다

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

구현한 적 없는 다크모드가 왜 되나 했는데
create next app으로 프로젝트를 생성할 때 자동으로 만들어진 globals.css에 다크모드 관련 내용이 있는걸 확인해서 지웠습니다
뒤늦게 수정해서 죄송합니다

+ 8.26 금 02:27 추가
main페이지 carousel의 dots에 클릭 버그가 있다는 피드백이 있던걸로 기억해서
dots도 삭제했습니다

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

> 다크모드 css를 삭제한 이유

로그인 모달 뿐 아니라 Tab 등이 다크모드로 내용이 보이지 않는데
다크모드 기능을 추가하려면 아예 추가해야 한다고 생각해서
관련 css를 삭제해서 다크모드가 안되는걸로 (그냥 저희 css로 보이게) 했습니다

> 수정 이후 예정

1. 이 PR approve 이후 dev로 병합
2. dev를 다시 main으로 병합
3. main이 바뀌었으니 vercel이 자동배포
4. 다크모드 수정된 main을 바탕으로 release 1.0.1 브랜치 생성

### 🚀 연관된 이슈
close issue #192 