### PR TITLE
#196/study detail page fix

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,8 +10,6 @@ const nextConfig = {
   },
   images: {
     domains: [
-      "i.picsum.photos",
-      "picsum.photos",
       "shopping-phinf.pstatic.net",
       "s3.ap-northeast-2.amazonaws.com",
       "via.placeholder.com",

--- a/pages/study/[id].tsx
+++ b/pages/study/[id].tsx
@@ -200,7 +200,7 @@ const StudyDetailPage = ({ studyData }: ServerSidePropType) => {
           <Tab label="공지" />
           <Tab label="자유" />
         </Tabs>
-        <S.ButtonsWrapper>
+        <S.ButtonsWrapper className={isOwner ? "owner" : "general"}>
           {isOwner && (
             <>
               <ApplicantList

--- a/styles/StudyDetailPageStyle.tsx
+++ b/styles/StudyDetailPageStyle.tsx
@@ -4,7 +4,7 @@ export const TabsContainer = styled.div`
   display: flex;
   justify-content: space-between;
   margin: 1rem;
-  @media screen and (max-width: 475px) {
+  @media screen and (max-width: 512px) {
     display: flex;
     flex-direction: column;
     gap: 1rem;
@@ -16,7 +16,7 @@ export const ButtonsWrapper = styled.div`
   gap: 1rem;
   align-self: ${(props) =>
     props.className === "owner" ? "flex-start" : "flex-end"};
-  @media screen and (max-width: 475px) {
+  @media screen and (max-width: 512px) {
     & Button {
       font-size: 0.8rem;
     }

--- a/styles/StudyDetailPageStyle.tsx
+++ b/styles/StudyDetailPageStyle.tsx
@@ -4,11 +4,23 @@ export const TabsContainer = styled.div`
   display: flex;
   justify-content: space-between;
   margin: 1rem;
+  @media screen and (max-width: 475px) {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
 `;
 
 export const ButtonsWrapper = styled.div`
   display: flex;
   gap: 1rem;
+  align-self: ${(props) =>
+    props.className === "owner" ? "flex-start" : "flex-end"};
+  @media screen and (max-width: 475px) {
+    & Button {
+      font-size: 0.8rem;
+    }
+  }
 `;
 
 export const StyledUl = styled.ul`
@@ -19,11 +31,16 @@ export const StyledUl = styled.ul`
   align-items: start;
   -webkit-padding-start: 0px;
 
-  @media (max-width: 512px) {
+  @media screen and (max-width: 1440px) {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+  }
+
+  @media screen and (max-width: 800px) {
     grid-template-columns: 1fr 1fr;
   }
-  @media (max-width: 1440px) {
-    grid-template-columns: 1fr 1fr 1fr;
+
+  @media screen and (max-width: 512px) {
+    grid-template-columns: 1fr;
   }
 `;
 
@@ -35,7 +52,6 @@ export const StyledList = styled.li`
 `;
 
 export const NoPost = styled.div`
-  width: 100%;
   margin-top: 5rem;
   text-align: center;
 `;


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

[ 800 px ]
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/32607413/187214912-5d967482-6c06-4c7d-9ef3-f635c954cbb5.png">

[512 px]
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/32607413/187215287-4819ece5-fa5e-4ce4-adf5-395cec6ba1b0.png">



### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

800px 이하에서는 2개의 columns를 보여줍니다.

512px 이하에서는 1개의 columns를 보여주고

공지/자유 탭과 버튼을 담고 있는 div의 flex-direction을 column으로 변경합니다.


### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

임의로 사이즈를 정한거라 명확하지 않습니다...

추가적으로  picsum 더미 이미지는 사용하지 않는다고 생각해서 nextjs.config 파일에서

picsum 도메인을 삭제했습니다.

### 🚀 연관된 이슈

close #196 